### PR TITLE
fix(auth): refresh user role from DB on JWT token refresh

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -6,6 +6,26 @@ import { authConfig } from "./auth.config";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   ...authConfig,
+  callbacks: {
+    ...authConfig.callbacks,
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = user.id;
+        token.role = user.role;
+      } else if (token.id) {
+        // Refresh role from DB on token refresh so admin promotion takes effect
+        // without requiring re-login
+        const dbUser = await prisma.user.findUnique({
+          where: { id: token.id as string },
+          select: { role: true },
+        });
+        if (dbUser) {
+          token.role = dbUser.role;
+        }
+      }
+      return token;
+    },
+  },
   providers: [
     Credentials({
       name: "credentials",


### PR DESCRIPTION
Previously the role was only set on initial sign-in, so admin promotion via ADMIN_EMAILS took effect only after re-login.