### PR TITLE
perf: lazy-load heavy client libraries (echarts, exceljs, chart compo…

### DIFF
--- a/apps/web/app/[locale]/admin/instances/components/instance-form.tsx
+++ b/apps/web/app/[locale]/admin/instances/components/instance-form.tsx
@@ -226,7 +226,7 @@ export function InstanceForm({ instance, venues, trigger }: InstanceFormProps) {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto" onInteractOutside={(e) => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle>
             {currentInstance ? "Edit Instance" : "New Instance"}

--- a/apps/web/app/[locale]/explore/toolbox/matcher/components/steps/upload-step.tsx
+++ b/apps/web/app/[locale]/explore/toolbox/matcher/components/steps/upload-step.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Workbook } from "exceljs";
 import { v4 as uuidv4 } from "uuid";
 import { FileDropzone } from "../file-dropzone";
 import { Button } from "@/components/ui/button";
@@ -27,6 +26,7 @@ interface UploadStepProps {
 }
 
 async function parseExcelFile(file: File): Promise<ParsedQuery[]> {
+  const { Workbook } = await import("exceljs");
   const buffer = await file.arrayBuffer();
   const workbook = new Workbook();
   await workbook.xlsx.load(buffer);

--- a/apps/web/components/explore/conferences/charts/keyword-cloud.tsx
+++ b/apps/web/components/explore/conferences/charts/keyword-cloud.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
-import * as echarts from "echarts";
 import { KeywordStats } from "@/lib/explore/types";
 import type { ECharts } from "echarts";
 
@@ -30,11 +29,15 @@ export function KeywordCloud({ data, className }: KeywordCloudProps) {
   const { resolvedTheme } = useTheme();
   const [isReady, setIsReady] = useState(false);
 
-  // Dynamically import echarts-wordcloud on client only
+  // Dynamically import echarts + wordcloud on client only
+  const echartsRef = useRef<typeof import("echarts") | null>(null);
   useEffect(() => {
-    import("echarts-wordcloud").then(() => {
-      setIsReady(true);
-    });
+    Promise.all([import("echarts"), import("echarts-wordcloud")]).then(
+      ([mod]) => {
+        echartsRef.current = mod;
+        setIsReady(true);
+      },
+    );
   }, []);
 
   const wordData = useMemo(() => {
@@ -50,14 +53,14 @@ export function KeywordCloud({ data, className }: KeywordCloudProps) {
   }, [data]);
 
   useEffect(() => {
-    if (!isReady || !chartRef.current || wordData.length === 0) return;
+    if (!isReady || !echartsRef.current || !chartRef.current || wordData.length === 0) return;
 
     if (chartInstance.current && !chartInstance.current.isDisposed()) {
       chartInstance.current.dispose();
       chartInstance.current = null;
     }
 
-    chartInstance.current = echarts.init(
+    chartInstance.current = echartsRef.current.init(
       chartRef.current,
       resolvedTheme === "dark" ? "dark" : undefined,
     );

--- a/apps/web/components/explore/conferences/publication-stats-section.tsx
+++ b/apps/web/components/explore/conferences/publication-stats-section.tsx
@@ -1,15 +1,40 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { ConferenceStats } from "@/lib/explore/types";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
-import { StatusPieChart } from "./charts/status-pie-chart";
-import { KeywordCloud } from "./charts/keyword-cloud";
-import { AffiliationBarChart } from "./charts/affiliation-bar-chart";
-import { CountryBarChart } from "./charts/country-bar-chart";
-import { TopicBarChart } from "./charts/topic-bar-chart";
-import { CollaborationNetwork } from "./charts/collaboration-network";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function ChartSkeleton({ className }: { className?: string }) {
+  return <Skeleton className={`w-full ${className || "h-70"}`} />;
+}
+
+const StatusPieChart = dynamic(
+  () => import("./charts/status-pie-chart").then((m) => ({ default: m.StatusPieChart })),
+  { loading: () => <ChartSkeleton />, ssr: false },
+);
+const KeywordCloud = dynamic(
+  () => import("./charts/keyword-cloud").then((m) => ({ default: m.KeywordCloud })),
+  { loading: () => <ChartSkeleton />, ssr: false },
+);
+const AffiliationBarChart = dynamic(
+  () => import("./charts/affiliation-bar-chart").then((m) => ({ default: m.AffiliationBarChart })),
+  { loading: () => <ChartSkeleton className="h-100" />, ssr: false },
+);
+const CountryBarChart = dynamic(
+  () => import("./charts/country-bar-chart").then((m) => ({ default: m.CountryBarChart })),
+  { loading: () => <ChartSkeleton className="h-100" />, ssr: false },
+);
+const TopicBarChart = dynamic(
+  () => import("./charts/topic-bar-chart").then((m) => ({ default: m.TopicBarChart })),
+  { loading: () => <ChartSkeleton />, ssr: false },
+);
+const CollaborationNetwork = dynamic(
+  () => import("./charts/collaboration-network").then((m) => ({ default: m.CollaborationNetwork })),
+  { loading: () => <ChartSkeleton className="h-100" />, ssr: false },
+);
 
 interface PublicationStatsSectionProps {
   venueId: string;

--- a/apps/web/components/explore/toolbox/matcher/steps/upload-step.tsx
+++ b/apps/web/components/explore/toolbox/matcher/steps/upload-step.tsx
@@ -2,7 +2,6 @@
 
 import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Workbook } from "exceljs";
 import { v4 as uuidv4 } from "uuid";
 import { FileDropzone } from "../file-dropzone";
 import { Button } from "@/components/ui/button";
@@ -33,6 +32,7 @@ interface UploadStepProps {
 }
 
 async function parseExcelFile(file: File): Promise<ParsedQuery[]> {
+  const { Workbook } = await import("exceljs");
   const buffer = await file.arrayBuffer();
   const workbook = new Workbook();
   await workbook.xlsx.load(buffer);

--- a/apps/web/lib/hooks/use-echarts.ts
+++ b/apps/web/lib/hooks/use-echarts.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
-import * as echarts from "echarts";
 import type { EChartsOption, ECharts } from "echarts";
 
 interface UseEChartsOptions {
@@ -25,17 +24,23 @@ export function useECharts({ option }: UseEChartsOptions) {
   useEffect(() => {
     if (!isMounted || !chartRef.current) return;
 
-    const theme = resolvedTheme === "dark" ? "dark" : undefined;
+    let cancelled = false;
 
-    // Dispose existing instance if theme changes
-    if (chartInstance.current) {
-      chartInstance.current.dispose();
-      chartInstance.current = null;
-    }
+    import("echarts").then((echarts) => {
+      if (cancelled || !chartRef.current) return;
 
-    // Initialize chart with theme
-    chartInstance.current = echarts.init(chartRef.current, theme);
-    chartInstance.current.setOption(option);
+      const theme = resolvedTheme === "dark" ? "dark" : undefined;
+
+      // Dispose existing instance if theme changes
+      if (chartInstance.current) {
+        chartInstance.current.dispose();
+        chartInstance.current = null;
+      }
+
+      // Initialize chart with theme
+      chartInstance.current = echarts.init(chartRef.current, theme);
+      chartInstance.current.setOption(option);
+    });
 
     // Handle resize
     const handleResize = () => {
@@ -47,6 +52,7 @@ export function useECharts({ option }: UseEChartsOptions) {
 
     // Cleanup
     return () => {
+      cancelled = true;
       window.removeEventListener("resize", handleResize);
       if (chartInstance.current && !chartInstance.current.isDisposed()) {
         chartInstance.current.dispose();

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,14 +14,19 @@ const nextConfig: NextConfig = {
     optimizePackageImports: [
       "lucide-react",
       "framer-motion",
-      "recharts",
       "echarts",
+      "date-fns",
       "@copilotkit/react-core",
       "@copilotkit/react-ui",
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-dropdown-menu",
+      "@radix-ui/react-tabs",
+      "@radix-ui/react-select",
+      "@radix-ui/react-popover",
     ],
   },
   // Prevent Turbopack from bundling native/heavy server-only packages
-  serverExternalPackages: ["playwright", "pg", "@prisma/adapter-pg", "jszip", "graphology", "graphology-communities-louvain"],
+  serverExternalPackages: ["playwright", "pg", "@prisma/adapter-pg", "jszip", "graphology", "graphology-communities-louvain", "openai", "bcryptjs"],
   // Allow dev server access from local network IPs (for remote development)
   allowedDevOrigins: ["10.218.163.144", "*.local"],
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,7 +56,6 @@
     "react-dom": "^19.2.4",
     "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^10.1.0",
-    "recharts": "^3.7.0",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",


### PR DESCRIPTION
…nents)

- Dynamic import echarts in use-echarts hook and keyword-cloud (~1.4MB deferred)
- Dynamic import exceljs in both upload-step components (~2MB deferred)
- Convert all chart imports in publication-stats-section to next/dynamic with ssr:false
- Remove unused recharts dependency (~400KB removed)
- Add date-fns, Radix UI primitives to optimizePackageImports
- Add openai, bcryptjs to serverExternalPackages
- Fix format guide dialog: wider layout, copy includes schema notes