### PR TITLE
feat: session stats dashboard and improved calendar layout

### DIFF
--- a/apps/web/app/[locale]/explore/conferences/[id]/page.tsx
+++ b/apps/web/app/[locale]/explore/conferences/[id]/page.tsx
@@ -6,7 +6,7 @@ import {
   getConferenceStats,
   getConferenceSessions,
 } from "@/lib/explore/queries";
-import { ConferenceHero, SessionCalendar } from "@/components/explore/conferences";
+import { ConferenceHero, SessionCalendar, SessionStatsSection } from "@/components/explore/conferences";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SetAIContext } from "@/components/explore/set-ai-context";
@@ -17,9 +17,14 @@ interface PageProps {
 
 import { PublicationStatsSection } from "@/components/explore/conferences/publication-stats-section";
 
-async function SessionsCalendarSection({ conferenceId }: { conferenceId: string }) {
+async function SessionsSection({ conferenceId }: { conferenceId: string }) {
   const sessions = await getConferenceSessions(conferenceId);
-  return <SessionCalendar sessions={sessions} />;
+  return (
+    <div className="flex flex-col gap-10">
+      <SessionStatsSection sessions={sessions} />
+      <SessionCalendar sessions={sessions} />
+    </div>
+  );
 }
 
 export default async function ConferenceDetailPage({ params }: PageProps) {
@@ -79,7 +84,7 @@ export default async function ConferenceDetailPage({ params }: PageProps) {
 
         <TabsContent value="sessions" className="mt-8">
           <Suspense fallback={<ContentSkeleton />}>
-            <SessionsCalendarSection conferenceId={id} />
+            <SessionsSection conferenceId={id} />
           </Suspense>
         </TabsContent>
       </Tabs>

--- a/apps/web/components/explore/conferences/charts/session-daily-chart.tsx
+++ b/apps/web/components/explore/conferences/charts/session-daily-chart.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMemo } from "react";
+import { useECharts } from "@/lib/hooks/use-echarts";
+import type { EChartsOption } from "echarts";
+
+interface SessionDailyChartProps {
+  data: { date: string; label: string; count: number }[];
+}
+
+export function SessionDailyChart({ data }: SessionDailyChartProps) {
+  const option = useMemo<EChartsOption>(() => {
+    if (!data || data.length === 0) return {};
+
+    return {
+      tooltip: {
+        trigger: "axis",
+        axisPointer: { type: "shadow" },
+        formatter: (params: any) => {
+          const p = params[0];
+          return `${p.name}<br/>Sessions: <strong>${p.value}</strong>`;
+        },
+      },
+      grid: { left: 10, right: 20, top: 20, bottom: 10, containLabel: true },
+      xAxis: {
+        type: "category",
+        data: data.map((d) => d.label),
+        axisLabel: { fontSize: 11, rotate: data.length > 5 ? 30 : 0 },
+        axisLine: { show: false },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: "value",
+        axisLabel: { fontSize: 11 },
+        splitLine: { lineStyle: { type: "dashed", opacity: 0.3 } },
+        axisLine: { show: false },
+      },
+      series: [
+        {
+          type: "bar",
+          data: data.map((d) => d.count),
+          itemStyle: {
+            color: "#6366f1",
+            borderRadius: [4, 4, 0, 0],
+          },
+          barMaxWidth: 40,
+          label: {
+            show: true,
+            position: "top",
+            fontSize: 11,
+            color: "inherit",
+          },
+        },
+      ],
+    };
+  }, [data]);
+
+  const chartRef = useECharts({ option });
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        No daily data available
+      </div>
+    );
+  }
+
+  return <div ref={chartRef} className="w-full h-full min-h-62.5" />;
+}

--- a/apps/web/components/explore/conferences/charts/session-speaker-chart.tsx
+++ b/apps/web/components/explore/conferences/charts/session-speaker-chart.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMemo } from "react";
+import { useECharts } from "@/lib/hooks/use-echarts";
+import type { EChartsOption } from "echarts";
+
+interface SessionSpeakerChartProps {
+  data: { speaker: string; count: number }[];
+}
+
+export function SessionSpeakerChart({ data }: SessionSpeakerChartProps) {
+  const option = useMemo<EChartsOption>(() => {
+    if (!data || data.length === 0) return {};
+
+    const sorted = [...data].sort((a, b) => a.count - b.count).slice(-10);
+    const names = sorted.map((d) =>
+      d.speaker.length > 25 ? `${d.speaker.substring(0, 25)}...` : d.speaker,
+    );
+    const values = sorted.map((d) => d.count);
+
+    return {
+      tooltip: {
+        trigger: "axis",
+        axisPointer: { type: "shadow" },
+        formatter: (params: any) => {
+          const idx = params[0].dataIndex;
+          return `${sorted[idx].speaker}<br/>Sessions: <strong>${params[0].value}</strong>`;
+        },
+      },
+      grid: { left: 10, right: 30, top: 10, bottom: 10, containLabel: true },
+      xAxis: {
+        type: "value",
+        axisLabel: { show: false },
+        splitLine: { show: false },
+        axisLine: { show: false },
+      },
+      yAxis: {
+        type: "category",
+        data: names,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { fontSize: 11, width: 120, overflow: "truncate" },
+      },
+      series: [
+        {
+          type: "bar",
+          data: values,
+          itemStyle: {
+            color: "#10b981",
+            borderRadius: [0, 4, 4, 0],
+          },
+          barWidth: 18,
+          label: {
+            show: true,
+            position: "right",
+            fontSize: 10,
+            color: "inherit",
+          },
+        },
+      ],
+    };
+  }, [data]);
+
+  const chartRef = useECharts({ option });
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        No speaker data available
+      </div>
+    );
+  }
+
+  return <div ref={chartRef} className="w-full h-full min-h-62.5" />;
+}

--- a/apps/web/components/explore/conferences/charts/session-time-heatmap.tsx
+++ b/apps/web/components/explore/conferences/charts/session-time-heatmap.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useMemo } from "react";
+import { useECharts } from "@/lib/hooks/use-echarts";
+import type { EChartsOption } from "echarts";
+
+interface SessionTimeHeatmapProps {
+  data: { day: string; hour: string; count: number }[];
+  days: string[];
+  hours: string[];
+}
+
+export function SessionTimeHeatmap({ data, days, hours }: SessionTimeHeatmapProps) {
+  const option = useMemo<EChartsOption>(() => {
+    if (!data || data.length === 0) return {};
+
+    const maxCount = Math.max(...data.map((d) => d.count));
+
+    // ECharts heatmap expects [xIndex, yIndex, value]
+    const heatData = data.map((d) => [
+      days.indexOf(d.day),
+      hours.indexOf(d.hour),
+      d.count,
+    ]);
+
+    return {
+      tooltip: {
+        formatter: (params: any) => {
+          const [dayIdx, hourIdx, count] = params.data;
+          return `${days[dayIdx]}, ${hours[hourIdx]}<br/>Sessions: <strong>${count}</strong>`;
+        },
+      },
+      grid: { left: 60, right: 30, top: 10, bottom: 40 },
+      xAxis: {
+        type: "category",
+        data: days,
+        axisLabel: { fontSize: 11, rotate: days.length > 5 ? 30 : 0 },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitArea: { show: true },
+      },
+      yAxis: {
+        type: "category",
+        data: hours,
+        axisLabel: { fontSize: 11 },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitArea: { show: true },
+      },
+      visualMap: {
+        min: 0,
+        max: maxCount || 1,
+        calculable: false,
+        orient: "horizontal",
+        left: "center",
+        bottom: 0,
+        show: false,
+        inRange: {
+          color: ["#eef2ff", "#818cf8", "#4338ca"],
+        },
+      },
+      series: [
+        {
+          type: "heatmap",
+          data: heatData,
+          label: {
+            show: true,
+            fontSize: 11,
+            color: "inherit",
+          },
+          emphasis: {
+            itemStyle: {
+              shadowBlur: 10,
+              shadowColor: "rgba(0, 0, 0, 0.3)",
+            },
+          },
+          itemStyle: {
+            borderWidth: 2,
+            borderColor: "transparent",
+            borderRadius: 3,
+          },
+        },
+      ],
+    };
+  }, [data, days, hours]);
+
+  const chartRef = useECharts({ option });
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        No schedule data available
+      </div>
+    );
+  }
+
+  return <div ref={chartRef} className="w-full h-full min-h-62.5" />;
+}

--- a/apps/web/components/explore/conferences/charts/session-topic-chart.tsx
+++ b/apps/web/components/explore/conferences/charts/session-topic-chart.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMemo } from "react";
+import { useECharts } from "@/lib/hooks/use-echarts";
+import type { EChartsOption } from "echarts";
+
+interface SessionTopicChartProps {
+  data: { topic: string; count: number }[];
+}
+
+export function SessionTopicChart({ data }: SessionTopicChartProps) {
+  const option = useMemo<EChartsOption>(() => {
+    if (!data || data.length === 0) return {};
+
+    const sorted = [...data].sort((a, b) => a.count - b.count).slice(-10);
+    const names = sorted.map((d) =>
+      d.topic.length > 25 ? `${d.topic.substring(0, 25)}...` : d.topic,
+    );
+    const values = sorted.map((d) => d.count);
+
+    return {
+      tooltip: {
+        trigger: "axis",
+        axisPointer: { type: "shadow" },
+        formatter: (params: any) => {
+          const idx = params[0].dataIndex;
+          return `${sorted[idx].topic}<br/>Sessions: <strong>${params[0].value}</strong>`;
+        },
+      },
+      grid: { left: 10, right: 30, top: 10, bottom: 10, containLabel: true },
+      xAxis: {
+        type: "value",
+        axisLabel: { show: false },
+        splitLine: { show: false },
+        axisLine: { show: false },
+      },
+      yAxis: {
+        type: "category",
+        data: names,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { fontSize: 11, width: 120, overflow: "truncate" },
+      },
+      series: [
+        {
+          type: "bar",
+          data: values,
+          itemStyle: {
+            color: "#8b5cf6",
+            borderRadius: [0, 4, 4, 0],
+          },
+          barWidth: 18,
+          label: {
+            show: true,
+            position: "right",
+            fontSize: 10,
+            color: "inherit",
+          },
+        },
+      ],
+    };
+  }, [data]);
+
+  const chartRef = useECharts({ option });
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        No topic data available
+      </div>
+    );
+  }
+
+  return <div ref={chartRef} className="w-full h-full min-h-62.5" />;
+}

--- a/apps/web/components/explore/conferences/charts/session-type-pie-chart.tsx
+++ b/apps/web/components/explore/conferences/charts/session-type-pie-chart.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMemo } from "react";
+import { useECharts } from "@/lib/hooks/use-echarts";
+import type { EChartsOption } from "echarts";
+
+const TYPE_COLORS: Record<string, string> = {
+  Keynote: "#6366f1",
+  Workshop: "#f59e0b",
+  Tutorial: "#10b981",
+  "Paper Session": "#ef4444",
+  Panel: "#8b5cf6",
+  Demo: "#06b6d4",
+  Social: "#f97316",
+  "Poster Session": "#ec4899",
+};
+
+interface SessionTypePieChartProps {
+  data: { type: string; count: number }[];
+}
+
+export function SessionTypePieChart({ data }: SessionTypePieChartProps) {
+  const option = useMemo<EChartsOption>(() => {
+    if (!data || data.length === 0) return {};
+
+    const chartData = data
+      .map((item) => ({
+        name: item.type,
+        value: item.count,
+        itemStyle: {
+          color: TYPE_COLORS[item.type] || undefined,
+        },
+      }))
+      .sort((a, b) => b.value - a.value);
+
+    return {
+      tooltip: {
+        trigger: "item",
+        formatter: "{b}: {c} ({d}%)",
+      },
+      legend: {
+        orient: "vertical",
+        right: 10,
+        top: "center",
+        textStyle: { fontSize: 12 },
+      },
+      series: [
+        {
+          type: "pie",
+          radius: ["45%", "70%"],
+          center: ["35%", "50%"],
+          avoidLabelOverlap: true,
+          itemStyle: {
+            borderRadius: 4,
+            borderWidth: 2,
+            borderColor: "transparent",
+          },
+          label: { show: false },
+          emphasis: {
+            label: { show: true, fontSize: 14, fontWeight: "bold" },
+            itemStyle: {
+              shadowBlur: 10,
+              shadowOffsetX: 0,
+              shadowColor: "rgba(0, 0, 0, 0.3)",
+            },
+          },
+          data: chartData,
+        },
+      ],
+    };
+  }, [data]);
+
+  const chartRef = useECharts({ option });
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        No type data available
+      </div>
+    );
+  }
+
+  return <div ref={chartRef} className="w-full h-full min-h-62.5" />;
+}

--- a/apps/web/components/explore/conferences/index.ts
+++ b/apps/web/components/explore/conferences/index.ts
@@ -4,3 +4,4 @@ export { ConferenceCard } from "./conference-card";
 export { ConferenceGrid } from "./conference-grid";
 export { ConferenceHero } from "./conference-hero";
 export { SessionCalendar } from "./session-calendar";
+export { SessionStatsSection } from "./session-stats-section";

--- a/apps/web/components/explore/conferences/session-calendar.tsx
+++ b/apps/web/components/explore/conferences/session-calendar.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { MapPin, User, X } from "lucide-react";
+import { MapPin, User, Clock, X, Tag } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Select,
@@ -56,6 +56,23 @@ function getHourKey(startTime: string | null): string | null {
   return `${hour.toString().padStart(2, "0")}:00`;
 }
 
+function computeDuration(start: string | null, end: string | null): string | null {
+  if (!start || !end) return null;
+  const parseMinutes = (t: string) => {
+    const parts = t.split(":");
+    if (parts.length < 2) return null;
+    return parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10);
+  };
+  const s = parseMinutes(start);
+  const e = parseMinutes(end);
+  if (s === null || e === null || e <= s) return null;
+  const diff = e - s;
+  if (diff < 60) return `${diff}m`;
+  const h = Math.floor(diff / 60);
+  const m = diff % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
 function collectUnique(sessions: CalendarSessionItem[], field: "type"): string[];
 function collectUnique(sessions: CalendarSessionItem[], field: "topic" | "technology"): string[];
 function collectUnique(sessions: CalendarSessionItem[], field: "type" | "topic" | "technology"): string[] {
@@ -78,39 +95,73 @@ interface SessionCardProps {
 }
 
 function SessionCard({ session, color }: SessionCardProps) {
+  const duration = computeDuration(session.startTime, session.endTime);
+
   return (
     <div
-      className="w-70 shrink-0 rounded-lg bg-card border border-border hover:bg-muted/30 transition-colors"
+      className="rounded-lg bg-card border border-border hover:bg-muted/30 hover:border-muted-foreground/20 transition-colors"
       style={{ borderLeftWidth: 4, borderLeftColor: color }}
     >
       <Link
         href={`/explore/sessions/${session.id}`}
-        className="block p-3 space-y-2"
+        className="block p-3.5 space-y-2.5"
       >
         <h4 className="font-medium text-sm leading-snug line-clamp-2">
           {session.title}
         </h4>
-        {(session.startTime || session.endTime) && (
-          <p className="text-xs text-muted-foreground tabular-nums">
-            {session.startTime}
-            {session.endTime && ` – ${session.endTime}`}
-          </p>
+
+        {/* Time + Duration row */}
+        {(session.startTime || duration) && (
+          <div className="flex items-center gap-2">
+            <p className="text-xs text-muted-foreground tabular-nums flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {session.startTime}
+              {session.endTime && ` – ${session.endTime}`}
+            </p>
+            {duration && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
+                {duration}
+              </span>
+            )}
+          </div>
         )}
+
         {session.location && (
           <p className="text-xs text-muted-foreground flex items-center gap-1">
-            <MapPin className="h-3 w-3" />
+            <MapPin className="h-3 w-3 shrink-0" />
             <span className="truncate">{session.location}</span>
           </p>
         )}
+
         {session.speaker.length > 0 && (
           <p className="text-xs text-muted-foreground flex items-center gap-1">
-            <User className="h-3 w-3" />
+            <User className="h-3 w-3 shrink-0" />
             <span className="truncate">
               {session.speaker.slice(0, 2).join(", ")}
               {session.speaker.length > 2 &&
                 ` +${session.speaker.length - 2}`}
             </span>
           </p>
+        )}
+
+        {/* Topic tags */}
+        {session.topic.length > 0 && (
+          <div className="flex items-center gap-1 flex-wrap">
+            <Tag className="h-3 w-3 text-muted-foreground shrink-0" />
+            {session.topic.slice(0, 2).map((t) => (
+              <span
+                key={t}
+                className="text-[10px] px-1.5 py-0.5 rounded bg-muted/60 text-muted-foreground truncate max-w-30"
+              >
+                {t}
+              </span>
+            ))}
+            {session.topic.length > 2 && (
+              <span className="text-[10px] text-muted-foreground">
+                +{session.topic.length - 2}
+              </span>
+            )}
+          </div>
         )}
       </Link>
     </div>
@@ -277,21 +328,30 @@ export function SessionCalendar({ sessions }: SessionCalendarProps) {
       ) : (
         <Tabs value={effectiveTab} onValueChange={setActiveTab}>
           <TabsList className="bg-transparent rounded-none w-full justify-start h-auto p-0 gap-1 overflow-x-auto flex-nowrap">
-            {dateKeys.map((key) => (
-              <TabsTrigger
-                key={key}
-                value={key}
-                className="rounded-none border border-transparent bg-transparent data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary data-[state=inactive]:border-border data-[state=inactive]:text-muted-foreground px-3 py-1.5 text-sm font-medium shadow-none transition-colors whitespace-nowrap shrink-0"
-              >
-                {formatDateTab(new Date(key + "T00:00:00"))}
-              </TabsTrigger>
-            ))}
+            {dateKeys.map((key) => {
+              const count = dateGroups.get(key)?.length ?? 0;
+              return (
+                <TabsTrigger
+                  key={key}
+                  value={key}
+                  className="rounded-none border border-transparent bg-transparent data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary data-[state=inactive]:border-border data-[state=inactive]:text-muted-foreground px-3 py-1.5 text-sm font-medium shadow-none transition-colors whitespace-nowrap shrink-0"
+                >
+                  {formatDateTab(new Date(key + "T00:00:00"))}
+                  <span className="ml-1.5 tabular-nums opacity-70">
+                    ({count})
+                  </span>
+                </TabsTrigger>
+              );
+            })}
             {unscheduled.length > 0 && (
               <TabsTrigger
                 value="unscheduled"
                 className="rounded-none border border-transparent bg-transparent data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary data-[state=inactive]:border-border data-[state=inactive]:text-muted-foreground px-3 py-1.5 text-sm font-medium shadow-none transition-colors whitespace-nowrap shrink-0"
               >
                 Unscheduled
+                <span className="ml-1.5 tabular-nums opacity-70">
+                  ({unscheduled.length})
+                </span>
               </TabsTrigger>
             )}
           </TabsList>
@@ -344,29 +404,42 @@ function TimeSlotGrid({ sessions, typeColorMap }: TimeSlotGridProps) {
   }, [sessions]);
 
   return (
-    <div className="space-y-4">
-      {hourKeys.map((hour) => (
-        <div key={hour} className="flex gap-4">
-          <div className="w-16 shrink-0 pt-3 text-sm font-medium text-muted-foreground tabular-nums">
-            {hour}
+    <div className="space-y-6">
+      {hourKeys.map((hour) => {
+        const slotSessions = hourGroups.get(hour) ?? [];
+        return (
+          <div key={hour} className="flex gap-4">
+            <div className="w-16 shrink-0 pt-3">
+              <span className="text-sm font-medium text-muted-foreground tabular-nums">
+                {hour}
+              </span>
+              <span className="block text-[10px] text-muted-foreground/60 mt-0.5">
+                {slotSessions.length} session{slotSessions.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+            <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              {slotSessions.map((s) => (
+                <SessionCard
+                  key={s.id}
+                  session={s}
+                  color={s.type ? typeColorMap.get(s.type) ?? "#71717a" : "#71717a"}
+                />
+              ))}
+            </div>
           </div>
-          <div className="flex-1 flex gap-3 overflow-x-auto pb-2">
-            {(hourGroups.get(hour) ?? []).map((s) => (
-              <SessionCard
-                key={s.id}
-                session={s}
-                color={s.type ? typeColorMap.get(s.type) ?? "#71717a" : "#71717a"}
-              />
-            ))}
-          </div>
-        </div>
-      ))}
+        );
+      })}
       {noTime.length > 0 && (
         <div className="flex gap-4">
-          <div className="w-16 shrink-0 pt-3 text-sm font-medium text-muted-foreground">
-            Other
+          <div className="w-16 shrink-0 pt-3">
+            <span className="text-sm font-medium text-muted-foreground">
+              Other
+            </span>
+            <span className="block text-[10px] text-muted-foreground/60 mt-0.5">
+              {noTime.length} session{noTime.length !== 1 ? "s" : ""}
+            </span>
           </div>
-          <div className="flex-1 flex gap-3 overflow-x-auto pb-2">
+          <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
             {noTime.map((s) => (
               <SessionCard
                 key={s.id}

--- a/apps/web/components/explore/conferences/session-stats-section.tsx
+++ b/apps/web/components/explore/conferences/session-stats-section.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useMemo } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { CalendarSessionItem } from "@/lib/explore/types";
+
+function ChartSkeleton({ className }: { className?: string }) {
+  return <Skeleton className={`w-full ${className || "h-70"}`} />;
+}
+
+const SessionTypePieChart = dynamic(
+  () =>
+    import("./charts/session-type-pie-chart").then((m) => ({
+      default: m.SessionTypePieChart,
+    })),
+  { loading: () => <ChartSkeleton />, ssr: false },
+);
+const SessionDailyChart = dynamic(
+  () =>
+    import("./charts/session-daily-chart").then((m) => ({
+      default: m.SessionDailyChart,
+    })),
+  { loading: () => <ChartSkeleton />, ssr: false },
+);
+const SessionSpeakerChart = dynamic(
+  () =>
+    import("./charts/session-speaker-chart").then((m) => ({
+      default: m.SessionSpeakerChart,
+    })),
+  { loading: () => <ChartSkeleton className="h-100" />, ssr: false },
+);
+const SessionTopicChart = dynamic(
+  () =>
+    import("./charts/session-topic-chart").then((m) => ({
+      default: m.SessionTopicChart,
+    })),
+  { loading: () => <ChartSkeleton className="h-100" />, ssr: false },
+);
+const SessionTimeHeatmap = dynamic(
+  () =>
+    import("./charts/session-time-heatmap").then((m) => ({
+      default: m.SessionTimeHeatmap,
+    })),
+  { loading: () => <ChartSkeleton className="h-80" />, ssr: false },
+);
+
+interface SessionStatsSectionProps {
+  sessions: CalendarSessionItem[];
+}
+
+function computeStats(sessions: CalendarSessionItem[]) {
+  // Type distribution
+  const typeCounts = new Map<string, number>();
+  for (const s of sessions) {
+    const type = s.type || "Other";
+    typeCounts.set(type, (typeCounts.get(type) || 0) + 1);
+  }
+  const typeData = Array.from(typeCounts.entries())
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Daily distribution
+  const dayCounts = new Map<string, { label: string; count: number }>();
+  for (const s of sessions) {
+    if (!s.date) continue;
+    const d = new Date(s.date);
+    const key = d.toISOString().split("T")[0];
+    const label = d.toLocaleDateString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+    const existing = dayCounts.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      dayCounts.set(key, { label, count: 1 });
+    }
+  }
+  const dailyData = Array.from(dayCounts.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, { label, count }]) => ({ date, label, count }));
+
+  // Top speakers
+  const speakerCounts = new Map<string, number>();
+  for (const s of sessions) {
+    for (const sp of s.speaker) {
+      if (sp) speakerCounts.set(sp, (speakerCounts.get(sp) || 0) + 1);
+    }
+  }
+  const speakerData = Array.from(speakerCounts.entries())
+    .map(([speaker, count]) => ({ speaker, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Topic distribution
+  const topicCounts = new Map<string, number>();
+  for (const s of sessions) {
+    for (const t of s.topic) {
+      if (t) topicCounts.set(t, (topicCounts.get(t) || 0) + 1);
+    }
+  }
+  const topicData = Array.from(topicCounts.entries())
+    .map(([topic, count]) => ({ topic, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Time heatmap (day x hour)
+  const heatmapEntries = new Map<string, number>();
+  const daySet = new Set<string>();
+  const hourSet = new Set<string>();
+  for (const s of sessions) {
+    if (!s.date || !s.startTime) continue;
+    const d = new Date(s.date);
+    const dayLabel = d.toLocaleDateString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+    const hourMatch = s.startTime.match(/^(\d{1,2})/);
+    if (!hourMatch) continue;
+    const hour = `${parseInt(hourMatch[1], 10).toString().padStart(2, "0")}:00`;
+    daySet.add(dayLabel);
+    hourSet.add(hour);
+    const key = `${dayLabel}|${hour}`;
+    heatmapEntries.set(key, (heatmapEntries.get(key) || 0) + 1);
+  }
+
+  // Sort days chronologically using the dailyData order
+  const dayLabelsOrdered = dailyData.map((d) => d.label);
+  const days = dayLabelsOrdered.filter((d) => daySet.has(d));
+  const hours = Array.from(hourSet).sort();
+
+  const heatmapData: { day: string; hour: string; count: number }[] = [];
+  for (const day of days) {
+    for (const hour of hours) {
+      const count = heatmapEntries.get(`${day}|${hour}`) || 0;
+      if (count > 0) {
+        heatmapData.push({ day, hour, count });
+      }
+    }
+  }
+
+  return { typeData, dailyData, speakerData, topicData, heatmapData, days, hours };
+}
+
+export function SessionStatsSection({ sessions }: SessionStatsSectionProps) {
+  const stats = useMemo(() => computeStats(sessions), [sessions]);
+
+  const hasTypes = stats.typeData.length > 1;
+  const hasDays = stats.dailyData.length > 1;
+  const hasSpeakers = stats.speakerData.length > 0;
+  const hasTopics = stats.topicData.length > 0;
+  const hasHeatmap = stats.heatmapData.length > 0;
+
+  // Don't render stats section if no meaningful data
+  if (!hasTypes && !hasDays && !hasSpeakers && !hasTopics) return null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Row 1: Type Pie + Daily Bar + Heatmap */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-start">
+        {hasTypes && (
+          <div className="bg-card rounded-lg p-6">
+            <h3 className="text-sm font-semibold text-foreground/80 mb-4">
+              Session Types
+            </h3>
+            <div className="h-70">
+              <SessionTypePieChart data={stats.typeData} />
+            </div>
+          </div>
+        )}
+        {hasDays && (
+          <div className="bg-card rounded-lg p-6">
+            <h3 className="text-sm font-semibold text-foreground/80 mb-4">
+              Daily Distribution
+            </h3>
+            <div className="h-70">
+              <SessionDailyChart data={stats.dailyData} />
+            </div>
+          </div>
+        )}
+        {hasHeatmap && (
+          <div className="bg-card rounded-lg p-6">
+            <h3 className="text-sm font-semibold text-foreground/80 mb-4">
+              Schedule Density
+            </h3>
+            <div className="h-70">
+              <SessionTimeHeatmap
+                data={stats.heatmapData}
+                days={stats.days}
+                hours={stats.hours}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Row 2: Speakers + Topics */}
+      {(hasSpeakers || hasTopics) && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {hasSpeakers && (
+            <div className="bg-card rounded-lg p-6">
+              <h3 className="text-sm font-semibold text-foreground/80 mb-4">
+                Top Speakers
+              </h3>
+              <div className="h-100">
+                <SessionSpeakerChart data={stats.speakerData} />
+              </div>
+            </div>
+          )}
+          {hasTopics && (
+            <div className="bg-card rounded-lg p-6">
+              <h3 className="text-sm font-semibold text-foreground/80 mb-4">
+                Topic Coverage
+              </h3>
+              <div className="h-100">
+                <SessionTopicChart data={stats.topicData} />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add **session analytics dashboard** with 5 ECharts visualizations: type distribution pie, daily session bar, schedule density heatmap, top speakers, and topic coverage
- **Improve session calendar**: replace horizontal scroll with responsive wrapping grid, add session counts on date tabs, duration badges, topic tags on cards, and per-slot counts
- Stats section auto-hides when insufficient data; charts are lazy-loaded with `next/dynamic`

## Test plan
- [ ] Navigate to a conference with sessions and click the Sessions tab
- [ ] Verify stats charts render above the calendar (type pie, daily bar, heatmap, speakers, topics)
- [ ] Verify calendar cards show in a wrapping grid (not horizontal scroll)
- [ ] Verify date tabs show session counts, e.g., "Mon, Jan 15 (12)"
- [ ] Verify session cards show duration badges and topic tags
- [ ] Verify filters still work correctly
- [ ] Test on a conference with few/no sessions — stats section should hide gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)