### PR TITLE
fix: replace inline script with client component to avoid React warning

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 import { Providers } from "../providers";
+import { ScrollbarAutoHide } from "./scrollbar-autohide";
 import "../globals.css";
 import { routing } from "@/src/i18n/routing";
 
@@ -43,14 +43,7 @@ export default async function LocaleLayout({
       <body
         className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
       >
-        {/* Auto-hide scrollbar: show only while scrolling, hide after 800ms idle */}
-        <Script
-          id="scrollbar-autohide"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `(function(){var t=new WeakMap();document.addEventListener("scroll",function(e){var el=e.target;if(el===document)el=document.documentElement;if(!el||!el.dataset)return;el.dataset.scrolling="";var id=t.get(el);if(id)clearTimeout(id);t.set(el,setTimeout(function(){delete el.dataset.scrolling},800))},true)})()`,
-          }}
-        />
+        <ScrollbarAutoHide />
         <NextIntlClientProvider messages={messages}>
           <Providers>{children}</Providers>
         </NextIntlClientProvider>

--- a/apps/web/app/[locale]/scrollbar-autohide.tsx
+++ b/apps/web/app/[locale]/scrollbar-autohide.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ScrollbarAutoHide() {
+  useEffect(() => {
+    const timeouts = new WeakMap<Element, ReturnType<typeof setTimeout>>();
+    const handler = (e: Event) => {
+      let el = e.target as Element | null;
+      if (el === document as unknown) el = document.documentElement;
+      if (!el || !(el instanceof HTMLElement)) return;
+      el.dataset.scrolling = "";
+      const prev = timeouts.get(el);
+      if (prev) clearTimeout(prev);
+      timeouts.set(
+        el,
+        setTimeout(() => {
+          delete el.dataset.scrolling;
+        }, 800),
+      );
+    };
+    document.addEventListener("scroll", handler, true);
+    return () => document.removeEventListener("scroll", handler, true);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Move scrollbar auto-hide from <Script dangerouslySetInnerHTML> to a "use client" component with useEffect. Eliminates the "Encountered a script tag" console error.