### PR TITLE
feat(wechat): serve article images from DB and preserve HTML in noteb…

### DIFF
--- a/apps/web/app/[locale]/explore/social-media/wechat/[id]/page.tsx
+++ b/apps/web/app/[locale]/explore/social-media/wechat/[id]/page.tsx
@@ -33,6 +33,13 @@ export default async function WechatArticleDetailPage({ params }: PageProps) {
       })
     : null;
 
+  const coverImage = article.images.find((img) => img.image_type === "cover");
+  const coverSrc = coverImage
+    ? `/api/wechat/images/${coverImage.id}`
+    : article.cover_url
+      ? `/api/wechat/proxy-image?url=${encodeURIComponent(article.cover_url)}`
+      : null;
+
   return (
     <div className="flex flex-col gap-6">
       {/* Breadcrumb */}
@@ -74,6 +81,8 @@ export default async function WechatArticleDetailPage({ params }: PageProps) {
             title: article.title,
             originalUrl: article.original_url,
             contentText: article.content_text,
+            contentHtml: article.content_html,
+            images: article.images,
           }}
         />
       </div>
@@ -81,9 +90,9 @@ export default async function WechatArticleDetailPage({ params }: PageProps) {
       {/* Article content card */}
       <div className="rounded-xl border border-border bg-card overflow-hidden">
         {/* Cover image */}
-        {article.cover_url && (
+        {coverSrc && (
           <img
-            src={`/api/wechat/proxy-image?url=${encodeURIComponent(article.cover_url)}`}
+            src={coverSrc}
             alt=""
             className="w-full max-h-80 object-cover"
           />
@@ -94,6 +103,7 @@ export default async function WechatArticleDetailPage({ params }: PageProps) {
           <WechatArticleContent
             html={article.content_html}
             fallbackText={article.content_text}
+            images={article.images}
           />
         </div>
       </div>

--- a/apps/web/app/api/notebooks/[id]/sources/route.ts
+++ b/apps/web/app/api/notebooks/[id]/sources/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -49,10 +50,24 @@ export async function POST(req: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: "Notebook not found" }, { status: 404 });
   }
 
-  const { title, sourceType, url, content } = await req.json();
+  const { title, sourceType, url, content, contentHtml, wechatImages } = await req.json();
 
   if (!title?.trim()) {
     return NextResponse.json({ error: "Title is required" }, { status: 400 });
+  }
+
+  // Build metadata for WeChat HTML sources
+  let metadata: Prisma.InputJsonValue | undefined;
+  if (contentHtml || wechatImages) {
+    const meta: Record<string, Prisma.InputJsonValue> = {};
+    if (contentHtml) {
+      meta.contentHtml = contentHtml;
+      meta.renderMode = "html";
+    }
+    if (wechatImages) {
+      meta.wechatImages = wechatImages;
+    }
+    metadata = meta;
   }
 
   const source = await prisma.source.create({
@@ -64,6 +79,7 @@ export async function POST(req: NextRequest, context: RouteContext) {
       content: content || null,
       markdownContent: content || null,
       status: content ? "READY" : "PROCESSING",
+      ...(metadata && { metadata }),
     },
   });
 

--- a/apps/web/components/deepdive/sources/sources-panel.tsx
+++ b/apps/web/components/deepdive/sources/sources-panel.tsx
@@ -24,6 +24,8 @@ import { AddSourceDialog } from "@/components/deepdive/sources/add-source-dialog
 import { IngestReport } from "./ingest-report";
 import type { Source as PrismaSource } from "@prisma/client";
 import { Markdown } from "@/components/ui/markdown";
+import { WechatArticleContent } from "@/components/explore/social-media/wechat-article-content";
+import type { WechatImage } from "@/components/explore/social-media/wechat-article-content";
 import { useCollapsiblePanel } from "@/components/ui/collapsible-panel";
 import type { TocHeading } from "@/lib/utils/toc-extractor";
 // Extended Source type with the new content field (until Prisma client is regenerated)
@@ -33,6 +35,9 @@ type Source = PrismaSource & {
 
 interface SourceMetadata {
   toc?: TocHeading[];
+  renderMode?: string;
+  contentHtml?: string;
+  wechatImages?: WechatImage[];
   [key: string]: unknown;
 }
 
@@ -261,6 +266,11 @@ function SourceContentView({
   const panelContext = useCollapsiblePanel();
   const isAnimationComplete = panelContext?.isAnimationComplete ?? true;
 
+  const meta = source.metadata as SourceMetadata | null;
+  const isHtmlMode = meta?.renderMode === "html" && meta?.contentHtml;
+  const htmlContent = isHtmlMode ? (meta.contentHtml as string) : "";
+  const wechatImages = (meta?.wechatImages as WechatImage[] | undefined) ?? [];
+
   const markdownContent = source.content || "No content available";
   const [deferredContent, setDeferredContent] = useState<string | null>(null);
   const [, startTransition] = useTransition();
@@ -421,13 +431,19 @@ function SourceContentView({
         )}
       </div>
 
-      {/* Markdown content */}
+      {/* Content */}
       <div
         ref={scrollRef}
         className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-4"
         style={{ contain: "content" }}
       >
-        {deferredContent ? (
+        {isHtmlMode ? (
+          <WechatArticleContent
+            html={htmlContent}
+            fallbackText={source.content || ""}
+            images={wechatImages}
+          />
+        ) : deferredContent ? (
           <Markdown className="space-y-3 text-[14px] leading-5 text-muted-foreground">
             {deferredContent}
           </Markdown>

--- a/apps/web/components/explore/social-media/add-to-notebook-dialog.tsx
+++ b/apps/web/components/explore/social-media/add-to-notebook-dialog.tsx
@@ -24,6 +24,8 @@ interface AddToNotebookDialogProps {
     title: string;
     originalUrl: string;
     contentText: string;
+    contentHtml?: string;
+    images?: { id: number; image_type: string; original_url?: string }[];
   };
 }
 
@@ -70,6 +72,8 @@ export function AddToNotebookDialog({ article }: AddToNotebookDialogProps) {
           sourceType: "WEBPAGE",
           url: article.originalUrl,
           content: article.contentText,
+          contentHtml: article.contentHtml,
+          wechatImages: article.images,
         }),
       });
       if (res.ok) {

--- a/apps/web/components/explore/social-media/wechat-article-content.tsx
+++ b/apps/web/components/explore/social-media/wechat-article-content.tsx
@@ -3,30 +3,59 @@
 import DOMPurify from "dompurify";
 import { useEffect, useRef } from "react";
 
+export interface WechatImage {
+  id: number;
+  image_type: string;
+  image_index: number;
+  original_url?: string;
+}
+
 interface WechatArticleContentProps {
   html: string;
   fallbackText: string;
+  images?: WechatImage[];
 }
 
-export function WechatArticleContent({ html, fallbackText }: WechatArticleContentProps) {
+export function WechatArticleContent({ html, fallbackText, images }: WechatArticleContentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!containerRef.current) return;
-    const images = containerRef.current.querySelectorAll("img");
-    images.forEach((img) => {
-      // Resolve the actual image URL (prefer data-src for lazy images)
+
+    // Build a map from original WeChat CDN URLs to local DB image IDs
+    const urlToId = new Map<string, number>();
+    if (images) {
+      for (const img of images) {
+        if (img.original_url) {
+          urlToId.set(img.original_url, img.id);
+        }
+      }
+    }
+
+    const imgElements = containerRef.current.querySelectorAll("img");
+    imgElements.forEach((img) => {
       const originalSrc = img.getAttribute("data-src") || img.getAttribute("src") || "";
-      if (originalSrc) {
-        // Route all images through our proxy to handle referrer/user-agent issues
+      if (!originalSrc) return;
+
+      // Prefer DB-stored image if we have a match by original URL
+      const dbImageId = urlToId.get(originalSrc);
+      if (dbImageId) {
+        img.src = `/api/wechat/images/${dbImageId}`;
+      } else {
+        // Fallback to proxy for images not in the DB
         img.src = `/api/wechat/proxy-image?url=${encodeURIComponent(originalSrc)}`;
       }
-      // Hide broken images gracefully
+
       img.onerror = () => {
-        img.style.display = "none";
+        // If DB image failed, try proxy as last resort
+        if (dbImageId && !img.src.includes("proxy-image")) {
+          img.src = `/api/wechat/proxy-image?url=${encodeURIComponent(originalSrc)}`;
+        } else {
+          img.style.display = "none";
+        }
       };
     });
-  }, [html]);
+  }, [html, images]);
 
   if (!html) {
     return (

--- a/apps/web/lib/wechat/queries.ts
+++ b/apps/web/lib/wechat/queries.ts
@@ -30,7 +30,7 @@ export interface WechatArticleDetail {
   source_name: string;
   source_id: number;
   source_slug: string;
-  images: { id: number; image_type: string; image_index: number }[];
+  images: { id: number; image_type: string; image_index: number; original_url: string }[];
 }
 
 export async function getWechatSources(): Promise<WechatSource[]> {
@@ -110,7 +110,7 @@ export async function getWechatArticle(
   if (articleResult.rows.length === 0) return null;
 
   const imageResult = await wechatPool.query(
-    `SELECT id, image_type, image_index
+    `SELECT id, image_type, image_index, original_url
      FROM wechat_articles.images
      WHERE article_id = $1
      ORDER BY image_index`,


### PR DESCRIPTION
…ook imports

WeChat article images were previously fetched via proxy from CDN URLs that often expire. Now images are served from the local DB (bytea) via /api/wechat/images/[id] by matching original_url in the HTML content. When importing WeChat articles to notebooks, the original HTML + image metadata are stored so the notebook source viewer renders with native HTML formatting instead of plain markdown.