### PR TITLE
chore(agent): reorganize .env.example with all current params

### DIFF
--- a/apps/agent/.env.example
+++ b/apps/agent/.env.example
@@ -1,43 +1,64 @@
 # ============================================
-# SparkFlow Agent Service Configuration
+# SparkFlow Agent — Environment Variables
 # ============================================
-
-# AI Provider API Keys (only need the ones you use)
-OPENAI_API_KEY=your_openai_key_here
-GOOGLE_API_KEY=your_google_api_key_here
-
-# Default Model (used when user has no saved preference)
-DEFAULT_MODEL_PROVIDER=google
-DEFAULT_MODEL_NAME=gemini-2.5-flash
+# Copy to .env and fill in your values.
 
 # ============================================
-# PageIndex (document indexing & retrieval)
+# AI Provider API Keys
 # ============================================
-PAGEINDEX_MODEL=gpt-4o-2024-11-20
-PAGEINDEX_API_KEY=              # Optional: for PageIndex cloud API
+# Only the providers you use need to be set.
+# init_chat_model / ChatGoogleGenerativeAI read these automatically.
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+
+# ============================================
+# Default Model
+# ============================================
+# Fallback when no per-user BYOK preference is set.
+DEFAULT_MODEL_PROVIDER=openai
+DEFAULT_MODEL_NAME=gpt-4o
+
+# ============================================
+# SparkFlow Web API
+# ============================================
+# The agent calls back to the Next.js frontend for source content,
+# search endpoints, etc.
 SPARKFLOW_API_URL=http://localhost:3001
 
 # ============================================
-# Database (for LangGraph checkpoints & Hub agent)
+# Database (LangGraph checkpoints)
 # ============================================
-# NOTE: When running in Docker, use host.docker.internal instead of localhost
-CHECKPOINT_DB_URL=postgresql://sparkflow:sparkflow@host.docker.internal:5433/sparkflow_checkpoints
-DATABASE_URL=postgresql://sparkflow:sparkflow@host.docker.internal:5433/sparkflow
+# When running in Docker, use host.docker.internal instead of localhost.
+CHECKPOINT_DB_URL=postgresql://sparkflow:sparkflow@localhost:5433/sparkflow_checkpoints
 
 # ============================================
-# Optional: LangSmith for tracing
-# ============================================
-LANGSMITH_API_KEY=your_langsmith_api_key_here
-
-# ============================================
-# Query Optimization
-# ============================================
-ENABLE_PROMPT_OPTIMIZER=true
-
-# ============================================
-# Research Hub MCP Services
+# Research Hub Agent
 # ============================================
 TOOLBOX_SERVER_URL=http://localhost:5000/mcp
 MCP_SERVER_URL=http://localhost:3108/mcp
 HUB_MODEL_PROVIDER=openai
-HUB_MODEL_NAME=gpt-5.4
+HUB_MODEL_NAME=gpt-4o
+# HUB_MAX_BACKEND_ITERATIONS=6
+
+# ============================================
+# Search Agent
+# ============================================
+# Tavily API key for web search tool (required for web source type).
+# Get one at https://tavily.com
+TAVILY_API_KEY=
+
+# ============================================
+# WeChat Database (optional)
+# ============================================
+# External Postgres for WeChat article search (hub + search agents).
+# Leave empty if you don't use WeChat features.
+WECHAT_DATABASE_URL=
+
+# ============================================
+# Observability (optional)
+# ============================================
+# LangSmith tracing — set to enable trace logging.
+LANGSMITH_API_KEY=
+
+# Query optimizer for hub agent prompts.
+ENABLE_PROMPT_OPTIMIZER=true


### PR DESCRIPTION
- Add TAVILY_API_KEY (search agent web tool)
- Add WECHAT_DATABASE_URL (hub + search agents)
- Remove legacy vars: PAGEINDEX_MODEL, PAGEINDEX_API_KEY, DATABASE_URL
- Group by feature: AI providers, default model, SparkFlow API, database, hub agent, search agent, WeChat, observability
- Add comments explaining what each section is for