### PR TITLE
fix(agent): load apps/agent/.env explicitly in backfill scripts

### DIFF
--- a/apps/agent/.env.example
+++ b/apps/agent/.env.example
@@ -26,9 +26,13 @@ DEFAULT_MODEL_NAME=gpt-4o
 SPARKFLOW_API_URL=http://localhost:3001
 
 # ============================================
-# Database (LangGraph checkpoints)
+# Databases
 # ============================================
-# When running in Docker, use host.docker.internal instead of localhost.
+# Main SparkFlow DB — target for the embedding backfill scripts
+# (apps/agent/scripts/backfill_*.py). Must match apps/web .env.
+DATABASE_URL=postgresql://sparkflow:sparkflow@localhost:5433/sparkflow
+
+# LangGraph checkpoints. When running in Docker, use host.docker.internal.
 CHECKPOINT_DB_URL=postgresql://sparkflow:sparkflow@localhost:5433/sparkflow_checkpoints
 
 # ============================================

--- a/apps/agent/scripts/backfill_publication_embeddings.py
+++ b/apps/agent/scripts/backfill_publication_embeddings.py
@@ -99,7 +99,7 @@ async def backfill(batch_size: int, hard_limit: int | None) -> int:
 
 
 def main() -> int:
-    load_dotenv()
+    load_dotenv(ROOT / ".env")
     parser = argparse.ArgumentParser()
     parser.add_argument("--batch", type=int, default=16)
     parser.add_argument("--limit", type=int, default=None)

--- a/apps/agent/scripts/backfill_wechat_embeddings.py
+++ b/apps/agent/scripts/backfill_wechat_embeddings.py
@@ -185,7 +185,7 @@ async def run(mode: str, batch_size: int, hard_limit: int | None) -> dict[str, i
 
 
 def main() -> int:
-    load_dotenv()
+    load_dotenv(ROOT / ".env")
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--full",


### PR DESCRIPTION
Bare load_dotenv() reads from the CWD, so running the script from any directory other than apps/agent silently left DATABASE_URL / WECHAT_DATABASE_URL unset — psycopg then fell back to a UNIX socket connection under the OS user, which fails on servers. Point load_dotenv at apps/agent/.env directly, and document DATABASE_URL in .env.example so operators know both DSNs need to live there.