### PR TITLE
chore(web): add pm2 ecosystem config and deploy script

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -37,6 +37,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# pm2 runtime logs
+.pm2-logs/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/apps/web/ecosystem.config.js
+++ b/apps/web/ecosystem.config.js
@@ -1,0 +1,34 @@
+// PM2 process definition for the SparkFlow web app.
+// Usage on the server:
+//   cd apps/web && pm2 start ecosystem.config.js && pm2 save
+// After code updates:
+//   pm2 restart sparkflow-web
+//
+// Override PORT via env: `PORT=3001 pm2 restart sparkflow-web --update-env`.
+
+const path = require("node:path");
+
+module.exports = {
+  apps: [
+    {
+      name: "sparkflow-web",
+      cwd: __dirname,
+      script: "npm",
+      args: `run start -- --port ${process.env.PORT || 3003}`,
+      node_args: "--disable-warning=UNDICI-EHPA",
+      instances: 1,
+      exec_mode: "fork",
+      max_memory_restart: "1G",
+      autorestart: true,
+      watch: false,
+      env: {
+        NODE_ENV: "production",
+        NODE_OPTIONS: "--disable-warning=UNDICI-EHPA",
+      },
+      error_file: path.join(__dirname, ".pm2-logs", "err.log"),
+      out_file: path.join(__dirname, ".pm2-logs", "out.log"),
+      merge_logs: true,
+      time: true,
+    },
+  ],
+};

--- a/apps/web/scripts/deploy.sh
+++ b/apps/web/scripts/deploy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy loop for the sparkflow-web process on a server.
+# Run from any cwd — resolves its own location.
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WEB_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+REPO_ROOT=$(cd "$WEB_DIR/../.." && pwd)
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+cd "$REPO_ROOT"
+echo -e "${YELLOW}› git pull${NC}"
+git pull
+
+cd "$WEB_DIR"
+echo -e "${YELLOW}› npm ci${NC}"
+npm ci
+
+echo -e "${YELLOW}› prisma generate${NC}"
+npx prisma generate
+
+echo -e "${YELLOW}› prisma migrate deploy${NC}"
+npx prisma migrate deploy
+
+echo -e "${YELLOW}› next build${NC}"
+npm run build
+
+if pm2 describe sparkflow-web >/dev/null 2>&1; then
+  echo -e "${YELLOW}› pm2 restart sparkflow-web${NC}"
+  pm2 restart sparkflow-web --update-env
+else
+  echo -e "${YELLOW}› pm2 start ecosystem.config.js${NC}"
+  pm2 start ecosystem.config.js
+  pm2 save
+fi
+
+echo -e "${GREEN}✓ deploy complete${NC}"
+pm2 status sparkflow-web


### PR DESCRIPTION
- `ecosystem.config.js` boots `npm run start` under pm2 with the UNDICI-EHPA warning silenced and NODE_ENV=production. Logs land in `apps/web/.pm2-logs/` (gitignored).
- `scripts/deploy.sh` runs the full deploy loop: git pull, npm ci, prisma generate + migrate deploy, build, pm2 restart (or start on first run).
- Port defaults to 3003; override with `PORT=<n>` before pm2 start.

Server bootstrap:
  npm install -g pm2 cd apps/web pm2 start ecosystem.config.js && pm2 save
  pm2 startup   # follow the printed instructions