### PR TITLE
chore(web): replace exceljs with SheetJS xlsx

### DIFF
--- a/apps/web/app/api/explore/instances/[instanceId]/export/route.ts
+++ b/apps/web/app/api/explore/instances/[instanceId]/export/route.ts
@@ -75,102 +75,109 @@ export async function GET(
       }),
     ]);
 
-    // Build Excel workbook with ExcelJS
-    const { Workbook } = await import("exceljs");
-    const workbook = new Workbook();
+    // Build Excel workbook with SheetJS
+    const XLSX = await import("xlsx");
+    const wb = XLSX.utils.book_new();
 
     // --- Publications sheet ---
-    const pubSheet = workbook.addWorksheet("Publications");
-    pubSheet.columns = [
-      { header: "Title", key: "title", width: 50 },
-      { header: "Authors", key: "authors", width: 40 },
-      { header: "Abstract", key: "abstract", width: 80 },
-      { header: "Summary", key: "summary", width: 80 },
-      { header: "Affiliations", key: "affiliations", width: 40 },
-      { header: "Countries", key: "countries", width: 25 },
-      { header: "Keywords", key: "keywords", width: 35 },
-      { header: "Research Topic", key: "researchTopic", width: 25 },
-      { header: "Rating", key: "rating", width: 10 },
-      { header: "Status", key: "status", width: 15 },
-      { header: "DOI", key: "doi", width: 30 },
-      { header: "PDF URL", key: "pdfUrl", width: 40 },
-      { header: "GitHub URL", key: "githubUrl", width: 40 },
-      { header: "Website URL", key: "websiteUrl", width: 40 },
+    const pubHeaders = [
+      "Title",
+      "Authors",
+      "Abstract",
+      "Summary",
+      "Affiliations",
+      "Countries",
+      "Keywords",
+      "Research Topic",
+      "Rating",
+      "Status",
+      "DOI",
+      "PDF URL",
+      "GitHub URL",
+      "Website URL",
     ];
-
+    const pubRows: unknown[][] = [pubHeaders];
     for (const pub of publications) {
-      pubSheet.addRow({
-        title: pub.title,
-        authors: pub.authors.join("; "),
-        abstract: pub.abstract,
-        summary: pub.summary,
-        affiliations: pub.affiliations.join("; "),
-        countries: pub.countries.join("; "),
-        keywords: pub.keywords.join("; "),
-        researchTopic: pub.researchTopic,
-        rating: pub.rating,
-        status: pub.status,
-        doi: pub.doi,
-        pdfUrl: pub.pdfUrl,
-        githubUrl: pub.githubUrl,
-        websiteUrl: pub.websiteUrl,
-      });
+      pubRows.push([
+        pub.title,
+        pub.authors.join("; "),
+        pub.abstract,
+        pub.summary,
+        pub.affiliations.join("; "),
+        pub.countries.join("; "),
+        pub.keywords.join("; "),
+        pub.researchTopic,
+        pub.rating,
+        pub.status,
+        pub.doi,
+        pub.pdfUrl,
+        pub.githubUrl,
+        pub.websiteUrl,
+      ]);
     }
-
-    // Bold header row
-    pubSheet.getRow(1).font = { bold: true };
+    const pubSheet = XLSX.utils.aoa_to_sheet(pubRows);
+    pubSheet["!cols"] = [
+      { wch: 50 }, { wch: 40 }, { wch: 80 }, { wch: 80 }, { wch: 40 }, { wch: 25 },
+      { wch: 35 }, { wch: 25 }, { wch: 10 }, { wch: 15 }, { wch: 30 }, { wch: 40 },
+      { wch: 40 }, { wch: 40 },
+    ];
+    XLSX.utils.book_append_sheet(wb, pubSheet, "Publications");
 
     // --- Sessions sheet ---
-    const sessSheet = workbook.addWorksheet("Sessions");
-    sessSheet.columns = [
-      { header: "Title", key: "title", width: 50 },
-      { header: "Type", key: "type", width: 20 },
-      { header: "Date", key: "date", width: 15 },
-      { header: "Start Time", key: "startTime", width: 12 },
-      { header: "End Time", key: "endTime", width: 12 },
-      { header: "Location", key: "location", width: 25 },
-      { header: "Speaker", key: "speaker", width: 40 },
-      { header: "Abstract", key: "abstract", width: 80 },
-      { header: "Overview", key: "overview", width: 80 },
-      { header: "Transcript", key: "transcript", width: 80 },
-      { header: "Session URL", key: "sessionUrl", width: 40 },
-      { header: "Topics", key: "topic", width: 35 },
-      { header: "Affiliations", key: "affiliation", width: 40 },
-      { header: "Technologies", key: "technology", width: 35 },
-      { header: "Format", key: "sessionFormat", width: 15 },
-      { header: "Has Recording", key: "hasRecording", width: 15 },
-      { header: "Intended Audience", key: "intendedAudience", width: 25 },
+    const sessHeaders = [
+      "Title",
+      "Type",
+      "Date",
+      "Start Time",
+      "End Time",
+      "Location",
+      "Speaker",
+      "Abstract",
+      "Overview",
+      "Transcript",
+      "Session URL",
+      "Topics",
+      "Affiliations",
+      "Technologies",
+      "Format",
+      "Has Recording",
+      "Intended Audience",
     ];
-
+    const sessRows: unknown[][] = [sessHeaders];
     for (const sess of sessions) {
-      sessSheet.addRow({
-        title: sess.title,
-        type: sess.type,
-        date: sess.date ? new Intl.DateTimeFormat("en-CA").format(new Date(sess.date)) : null,
-        startTime: sess.startTime,
-        endTime: sess.endTime,
-        location: sess.location,
-        speaker: sess.speaker.join("; "),
-        abstract: sess.abstract,
-        overview: sess.overview,
-        transcript: sess.transcript,
-        sessionUrl: sess.sessionUrl,
-        topic: sess.topic.join("; "),
-        affiliation: sess.affiliation.join("; "),
-        technology: sess.technology.join("; "),
-        sessionFormat: sess.sessionFormat,
-        hasRecording: sess.hasRecording ? "Yes" : "No",
-        intendedAudience: sess.intendedAudience,
-      });
+      sessRows.push([
+        sess.title,
+        sess.type,
+        sess.date ? new Intl.DateTimeFormat("en-CA").format(new Date(sess.date)) : null,
+        sess.startTime,
+        sess.endTime,
+        sess.location,
+        sess.speaker.join("; "),
+        sess.abstract,
+        sess.overview,
+        sess.transcript,
+        sess.sessionUrl,
+        sess.topic.join("; "),
+        sess.affiliation.join("; "),
+        sess.technology.join("; "),
+        sess.sessionFormat,
+        sess.hasRecording ? "Yes" : "No",
+        sess.intendedAudience,
+      ]);
     }
-
-    sessSheet.getRow(1).font = { bold: true };
+    const sessSheet = XLSX.utils.aoa_to_sheet(sessRows);
+    sessSheet["!cols"] = [
+      { wch: 50 }, { wch: 20 }, { wch: 15 }, { wch: 12 }, { wch: 12 }, { wch: 25 },
+      { wch: 40 }, { wch: 80 }, { wch: 80 }, { wch: 80 }, { wch: 40 }, { wch: 35 },
+      { wch: 40 }, { wch: 35 }, { wch: 15 }, { wch: 15 }, { wch: 25 },
+    ];
+    XLSX.utils.book_append_sheet(wb, sessSheet, "Sessions");
 
     // Write to buffer and return
-    const buffer = await workbook.xlsx.writeBuffer();
+    const buffer = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Buffer;
     const filename = `${instance.venue.name.toLowerCase()}-${instance.year}.xlsx`;
 
-    return new Response(buffer as ArrayBuffer, {
+    return new Response(new Uint8Array(buffer), {
       headers: {
         "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "Content-Disposition": `attachment; filename="${filename}"`,

--- a/apps/web/components/explore/toolbox/matcher/steps/upload-step.tsx
+++ b/apps/web/components/explore/toolbox/matcher/steps/upload-step.tsx
@@ -25,19 +25,25 @@ interface UploadStepProps {
 }
 
 async function parseExcelFile(file: File): Promise<ParsedQuery[]> {
-  const { Workbook } = await import("exceljs");
+  const XLSX = await import("xlsx");
   const buffer = await file.arrayBuffer();
-  const workbook = new Workbook();
-  await workbook.xlsx.load(buffer);
-  const worksheet = workbook.worksheets[0];
+  const workbook = XLSX.read(buffer, { type: "array" });
+  const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+  if (!worksheet) return [];
+
+  const rows = XLSX.utils.sheet_to_json<unknown[]>(worksheet, {
+    header: 1,
+    defval: "",
+    blankrows: false,
+  });
 
   const queries: ParsedQuery[] = [];
-  worksheet.eachRow((row, rowNumber) => {
-    const bu = String(row.getCell(1).value ?? "").trim();
-    const query = String(row.getCell(2).value ?? "").trim();
+  rows.forEach((row, idx) => {
+    const bu = String(row[0] ?? "").trim();
+    const query = String(row[1] ?? "").trim();
     if (!query || query.toLowerCase() === "query") return;
     if (!bu) return;
-    queries.push({ id: uuidv4(), bu, query, rowIndex: rowNumber });
+    queries.push({ id: uuidv4(), bu, query, rowIndex: idx + 1 });
   });
 
   return queries;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,6 @@
     "dompurify": "^3.4.0",
     "echarts": "^5.6.0",
     "echarts-wordcloud": "^2.1.0",
-    "exceljs": "^4.4.0",
     "framer-motion": "^12.23.26",
     "geist": "^1.5.1",
     "graphology": "^0.26.0",
@@ -64,6 +63,7 @@
     "turndown": "^7.2.4",
     "undici": "^7.21.0",
     "uuid": "^13.0.0",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Drops exceljs@4.4.0 and the five transitive deprecations it dragged in (inflight, rimraf@2, glob@7, fstream, lodash.isequal). exceljs is unmaintained since 2023, and its internal archiver/unzipper stack pins packages upstream will never update.

SheetJS xlsx@0.20.3 is sourced from the SheetJS CDN tarball — the npm-published 0.18.5 has an unpatched prototype-pollution + ReDoS pair (CVE-2023-30533, GHSA-5pgg-2g8v-p4x9). 0.20.3 is the current community build with both fixed.

Call-site changes
- app/api/explore/instances/[instanceId]/export/route.ts Workbook/addWorksheet/addRow rewritten as aoa_to_sheet + book_append_sheet, XLSX.write for buffer. Column widths preserved; bold header styling is dropped (SheetJS CE doesn't style cells). Buffer wrapped in Uint8Array since Response no longer accepts Node Buffer directly in Next 16.
- components/explore/toolbox/matcher/steps/upload-step.tsx XLSX.read + sheet_to_json { header: 1 } replaces the eachRow iterator. blankrows: false matches the old "skip empty rows" behaviour.

npm audit: xlsx vulnerabilities resolved. Remaining 3 moderate come from @hono/node-server via @prisma/dev, unrelated to this change.