### PR TITLE
fix(web): correct broken session links under /explore/conferences

### DIFF
--- a/apps/web/app/[locale]/explore/conferences/publications/[id]/page.tsx
+++ b/apps/web/app/[locale]/explore/conferences/publications/[id]/page.tsx
@@ -201,7 +201,7 @@ export default async function PublicationDetailPage({ params }: PageProps) {
                   <div className="flex items-center gap-3">
                     <h3 className="font-medium truncate flex-1 min-w-0">
                       <Link
-                        href={`/explore/sessions/${session.id}`}
+                        href={`/explore/conferences/sessions/${session.id}`}
                         className="after:absolute after:inset-0"
                       >
                         {session.title}

--- a/apps/web/app/[locale]/explore/conferences/sessions/[id]/not-found.tsx
+++ b/apps/web/app/[locale]/explore/conferences/sessions/[id]/not-found.tsx
@@ -13,7 +13,7 @@ export default function SessionNotFound() {
         This session may have been removed or doesn&apos;t exist.
       </p>
       <Button asChild className="mt-4">
-        <Link href="/explore/sessions">Browse all sessions</Link>
+        <Link href="/explore/conferences/sessions">Browse all sessions</Link>
       </Button>
     </div>
   );

--- a/apps/web/components/explore/conferences/session-calendar.tsx
+++ b/apps/web/components/explore/conferences/session-calendar.tsx
@@ -106,7 +106,7 @@ function SessionCard({ session, color }: SessionCardProps) {
       className="sf-card card-hoverable p-0 overflow-hidden"
       style={{ borderLeftWidth: 3, borderLeftColor: color }}
     >
-      <Link href={`/explore/sessions/${session.id}`} className="block p-4 space-y-2.5">
+      <Link href={`/explore/conferences/sessions/${session.id}`} className="block p-4 space-y-2.5">
         <div className="flex items-start justify-between gap-2">
           {session.type && (
             <span className="sf-badge sf-badge-muted">{session.type}</span>


### PR DESCRIPTION
Session cards on the conference detail page, related sessions on the publication detail page, and the session not-found fallback all pointed to /explore/sessions/* which is not a route, producing 404s. Point them at the real /explore/conferences/sessions/* path.