### PR TITLE
fix(web): use correct user_settings table name in semops rename migration

### DIFF
--- a/apps/web/prisma/migrations/20260422000000_rename_matcher_to_semops/migration.sql
+++ b/apps/web/prisma/migrations/20260422000000_rename_matcher_to_semops/migration.sql
@@ -1,6 +1,7 @@
 -- Rename UserSettings matcherModel* columns to semopsModel*.
 -- Hand-crafted to use RENAME COLUMN so existing rows keep their values
 -- (Prisma's default is DROP + ADD which would lose data).
+-- Table is mapped via @@map("user_settings") in the Prisma schema.
 
-ALTER TABLE "UserSettings" RENAME COLUMN "matcherModelProvider" TO "semopsModelProvider";
-ALTER TABLE "UserSettings" RENAME COLUMN "matcherModelName" TO "semopsModelName";
+ALTER TABLE "user_settings" RENAME COLUMN "matcherModelProvider" TO "semopsModelProvider";
+ALTER TABLE "user_settings" RENAME COLUMN "matcherModelName" TO "semopsModelName";


### PR DESCRIPTION
## Summary
- Fix the 20260422000000_rename_matcher_to_semops migration: it referenced `"UserSettings"` but the Prisma model maps to table `user_settings` via `@@map`.
- Result today: every `prisma migrate deploy` hits `relation "UserSettings" does not exist` and fails on the first ALTER.

## Why this is safe to edit in place
No database has successfully applied this migration — the first statement errors out, so the rename never ran. Databases that tried still have a failed entry in `_prisma_migrations`; operators must clear it before redeploying:

```bash
cd apps/web
npx prisma migrate resolve --rolled-back 20260422000000_rename_matcher_to_semops
npx prisma migrate deploy
```

## Test plan
- [ ] Merge, pull on production, run the two commands above, confirm `migrate deploy` reports the migration applied and the `user_settings` table now has `semopsModelProvider` / `semopsModelName` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)