### PR TITLE
chore(env): document WORKFLOWS_API_URL + INTERNAL_CALLBACK_TOKEN + se…

### DIFF
--- a/apps/agent/.env.example
+++ b/apps/agent/.env.example
@@ -22,8 +22,25 @@ DEFAULT_MODEL_NAME=gpt-4o
 # SparkFlow Web API
 # ============================================
 # The agent calls back to the Next.js frontend for source content,
-# search endpoints, etc.
+# search endpoints, and digest section completion callbacks.
 SPARKFLOW_API_URL=http://localhost:3001
+
+# ============================================
+# SemOps (operator library)
+# ============================================
+# Workflows (search, matcher, daily_digest) POST to
+# $SEMOPS_API_URL/api/operators/rank for semantic ranking.
+SEMOPS_API_URL=http://localhost:2025
+
+# ============================================
+# Digest Internal Callback
+# ============================================
+# Shared secret for authenticating the Python→Node callback when a
+# digest section completes. Python sends it as X-Internal-Token;
+# Node's /api/digest/sections/{id}/complete rejects mismatched requests.
+# Generate: openssl rand -hex 32
+# MUST match the same env in apps/web/.env.
+INTERNAL_CALLBACK_TOKEN=change_me_openssl_rand_hex_32
 
 # ============================================
 # Databases

--- a/apps/semops/.env.example
+++ b/apps/semops/.env.example
@@ -1,30 +1,29 @@
 # ============================================
-# SparkFlow Matcher Service Configuration
+# SparkFlow SemOps Service Configuration
 # ============================================
+# Pure semantic-operator library backing SparkFlow workflows
+# (sem_rank / sem_filter / sem_map / sem_agg). Matcher orchestration
+# moved to apps/agent/workflows/matcher/ in P5; this service is now
+# operators + RPC shell only.
 
 # Server
 PORT=2025
 
 # ============================================
-# AI Provider API Keys (for Query Optimizer)
-# Only need the ones you use
+# AI Provider API Keys (used by LOTUS LM when callers don't override)
+# Only need the ones you use.
 # ============================================
 GOOGLE_API_KEY=your_google_api_key_here
 OPENAI_API_KEY=your_openai_key_here
 
-# Default model for Query Optimizer
+# Default model when a caller's /api/operators/* request omits model_config.
 DEFAULT_MODEL_PROVIDER=google
 DEFAULT_MODEL_NAME=gemini-2.5-flash
 
 # ============================================
 # Xinference (Local LLM for LOTUS semantic matching)
-# This is ALWAYS used for semantic matching
+# Always used for sem_search embeddings / ranking.
 # ============================================
 XINFERENCE_BASE_URL=http://localhost:9997/v1
 XINFERENCE_MODEL=Qwen3-Instruct
 XINFERENCE_API_KEY=not-needed
-
-# ============================================
-# Query Optimizer Settings
-# ============================================
-ENABLE_MATCHER_QUERY_OPTIMIZER=true

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -40,11 +40,26 @@ DEFAULT_MODEL_NAME=gemini-2.5-flash
 # =============================================
 # 4. Backend Services
 # =============================================
-# LangGraph Agent (must be reachable from both server and browser)
+# LangGraph Agent (must be reachable from both server and browser).
+# Hosts the notebook, hub, and deep_research surface graphs.
 LANGGRAPH_API_URL=http://localhost:2024
 NEXT_PUBLIC_LANGGRAPH_API_URL=http://localhost:2024
 
-# SemOps Service (formerly Matcher)
+# Workflows server (apps/agent FastAPI).
+# Hosts /v1/workflows/search, /v1/workflows/matcher/jobs/*,
+# and /v1/workflows/daily_digest/sections/{id}/generate.
+WORKFLOWS_API_URL=http://localhost:2027
+NEXT_PUBLIC_WORKFLOWS_API_URL=http://localhost:2027
+
+# Shared secret for the Python→Node digest completion callback.
+# Python workflow sends it as X-Internal-Token; Node's
+# /api/digest/sections/{id}/complete rejects mismatched requests.
+# Generate: openssl rand -hex 32
+# MUST match the same env in apps/agent/.env.
+INTERNAL_CALLBACK_TOKEN=change_me_openssl_rand_hex_32
+
+# SemOps (pure operator library — sem_rank etc.)
+# Workflows call this server-to-server; browsers don't talk to it.
 NEXT_PUBLIC_SEMOPS_API_URL=http://localhost:2025
 # Deprecated alias, still honored as fallback:
 # NEXT_PUBLIC_MATCHER_API_URL=http://localhost:2025


### PR DESCRIPTION
…mops rename

Update all three .env.example files for the P4-P6 refactor deliverables:

- apps/web/.env.example: add WORKFLOWS_API_URL and NEXT_PUBLIC_WORKFLOWS_API_URL for apps/agent's FastAPI on :2027 (search, matcher, daily_digest); add INTERNAL_CALLBACK_TOKEN shared secret for the Python→Node digest completion callback; clarify that NEXT_PUBLIC_SEMOPS_API_URL is server-to-server only.
- apps/agent/.env.example: add SEMOPS_API_URL (workflows call /api/operators/rank); add INTERNAL_CALLBACK_TOKEN (must match apps/web).
- apps/semops/.env.example: rename header from "Matcher Service" to "SemOps Service"; note that matcher orchestration lives elsewhere now; drop ENABLE_MATCHER_QUERY_OPTIMIZER (matcher code no longer here).