### PR TITLE
chore(web): drop 9 unused env vars from .env.example

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,24 +21,8 @@ POSTGRES_DB=sparkflow
 POSTGRES_PORT=5433
 DATABASE_URL=postgresql://sparkflow:sparkflow@localhost:5433/sparkflow
 
-# WeChat Articles (external, read-only)
-WECHAT_DATABASE_URL=postgresql://user:pass@host:5432/wechat_db
-
 # =============================================
-# 3. AI / LLM
-# =============================================
-OPENAI_API_KEY=your_openai_key_here
-
-# Model catalog (comma-separated, shown in settings UI)
-OPENAI_MODELS=gpt-4o-mini,gpt-4.1,gpt-5.2
-GOOGLE_MODELS=gemini-2.5-flash,gemini-2.5-pro,gemini-1.5-flash
-
-# Default model for new users
-DEFAULT_MODEL_PROVIDER=google
-DEFAULT_MODEL_NAME=gemini-2.5-flash
-
-# =============================================
-# 4. Backend Services
+# 3. Backend Services
 # =============================================
 # LangGraph Agent (must be reachable from both server and browser).
 # Hosts the notebook, hub, and deep_research surface graphs.
@@ -48,6 +32,8 @@ NEXT_PUBLIC_LANGGRAPH_API_URL=http://localhost:2024
 # Workflows server (apps/agent FastAPI).
 # Hosts /v1/workflows/search, /v1/workflows/matcher/jobs/*,
 # and /v1/workflows/daily_digest/sections/{id}/generate.
+# Server-side routes read WORKFLOWS_API_URL; browser-bundled matcher
+# client reads NEXT_PUBLIC_WORKFLOWS_API_URL.
 WORKFLOWS_API_URL=http://localhost:2027
 NEXT_PUBLIC_WORKFLOWS_API_URL=http://localhost:2027
 
@@ -58,17 +44,8 @@ NEXT_PUBLIC_WORKFLOWS_API_URL=http://localhost:2027
 # MUST match the same env in apps/agent/.env.
 INTERNAL_CALLBACK_TOKEN=change_me_openssl_rand_hex_32
 
-# SemOps (pure operator library — sem_rank etc.)
-# Workflows call this server-to-server; browsers don't talk to it.
-NEXT_PUBLIC_SEMOPS_API_URL=http://localhost:2025
-# Deprecated alias, still honored as fallback:
-# NEXT_PUBLIC_MATCHER_API_URL=http://localhost:2025
-
-# MCP Server
-MCP_SERVER_URL=http://localhost:3108/mcp
-
 # =============================================
-# 5. MinerU (PDF Parsing)
+# 4. MinerU (PDF Parsing)
 # =============================================
 MINERU_MODE=local                    # "local" or "api"
 MINERU_LOCAL_URL=http://localhost:8000


### PR DESCRIPTION
Audited each entry against apps/web code with grep; these had zero refs outside node_modules and the example file itself:

- OPENAI_API_KEY, OPENAI_MODELS, GOOGLE_MODELS, DEFAULT_MODEL_PROVIDER, DEFAULT_MODEL_NAME — the web tier never reads LLM env vars directly; all AI calls go through resolveApiKey (BYOK) + config/models.json.
- NEXT_PUBLIC_SEMOPS_API_URL — matcher client flipped to WORKFLOWS_API_URL in P5; no caller reads the semops var anymore.
- NEXT_PUBLIC_MATCHER_API_URL — legacy alias, no fallback anywhere.
- MCP_SERVER_URL — MCP is consumed by apps/agent, not apps/web.
- WECHAT_DATABASE_URL — apps/web has only the primary Prisma DB; WeChat data is accessed via apps/agent which owns that env var.

Also added a one-line comment clarifying which WORKFLOWS_API_URL var is read on server vs browser.