### PR TITLE
feat(web): merge Upload files / Upload folder into a single Upload menu

### DIFF
--- a/apps/web/components/deepdive/sources/add-source-dialog.tsx
+++ b/apps/web/components/deepdive/sources/add-source-dialog.tsx
@@ -14,6 +14,8 @@ import {
   X,
   Check,
   ChevronDown,
+  FileText,
+  Folder,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -87,6 +89,7 @@ export function AddSourceDialog({ notebookId, open, onOpenChange }: AddSourceDia
   const [urlsText, setUrlsText] = useState("");
   const [showWebsites, setShowWebsites] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [isUploadMenuOpen, setIsUploadMenuOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
@@ -720,23 +723,51 @@ export function AddSourceDialog({ notebookId, open, onOpenChange }: AddSourceDia
                 )}
 
                 {/* Bottom Actions */}
-                <div className="grid grid-cols-3 gap-2.5 px-6 pb-6">
-                  <button
-                    disabled={isLimitReached}
-                    className="flex items-center justify-center gap-2 py-3 border border-border rounded-xl text-sm font-medium hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    <Upload className="h-4 w-4" />
-                    Upload files
-                  </button>
-                  <button
-                    disabled={isLimitReached}
-                    className="flex items-center justify-center gap-2 py-3 border border-border rounded-xl text-sm font-medium hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={() => folderInputRef.current?.click()}
-                  >
-                    <Upload className="h-4 w-4" />
-                    Upload folder
-                  </button>
+                <div className="grid grid-cols-2 gap-2.5 px-6 pb-6">
+                  <Popover open={isUploadMenuOpen} onOpenChange={setIsUploadMenuOpen}>
+                    <PopoverTrigger asChild>
+                      <button
+                        disabled={isLimitReached}
+                        className="flex items-center justify-center gap-2 py-3 border border-border rounded-xl text-sm font-medium hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        <Upload className="h-4 w-4" />
+                        Upload
+                        <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-56 p-1" align="start">
+                      <button
+                        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left hover:bg-accent/30 transition-colors"
+                        onClick={() => {
+                          setIsUploadMenuOpen(false);
+                          fileInputRef.current?.click();
+                        }}
+                      >
+                        <FileText className="h-5 w-5 shrink-0" />
+                        <div>
+                          <div className="text-sm font-semibold">Files</div>
+                          <div className="text-xs text-muted-foreground">
+                            Pick one or multiple files
+                          </div>
+                        </div>
+                      </button>
+                      <button
+                        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left hover:bg-accent/30 transition-colors"
+                        onClick={() => {
+                          setIsUploadMenuOpen(false);
+                          folderInputRef.current?.click();
+                        }}
+                      >
+                        <Folder className="h-5 w-5 shrink-0" />
+                        <div>
+                          <div className="text-sm font-semibold">Folder</div>
+                          <div className="text-xs text-muted-foreground">
+                            Upload every file in a folder
+                          </div>
+                        </div>
+                      </button>
+                    </PopoverContent>
+                  </Popover>
                   <button
                     disabled={isLimitReached}
                     className="flex items-center justify-center gap-2 py-3 border border-border rounded-xl text-sm font-medium hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
Replaces the three-button row (Upload files, Upload folder, Websites) with a two-button row: a single Upload trigger that opens a popover offering Files and Folder options, plus the existing Websites button. Drag-drop still accepts both files and folders transparently.