### PR TITLE
feat(web): single Upload button — files via picker, folders via drag-…

### DIFF
--- a/apps/web/components/deepdive/sources/add-source-dialog.tsx
+++ b/apps/web/components/deepdive/sources/add-source-dialog.tsx
@@ -14,8 +14,6 @@ import {
   X,
   Check,
   ChevronDown,
-  FileText,
-  Folder,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -89,9 +87,7 @@ export function AddSourceDialog({ notebookId, open, onOpenChange }: AddSourceDia
   const [urlsText, setUrlsText] = useState("");
   const [showWebsites, setShowWebsites] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  const [isUploadMenuOpen, setIsUploadMenuOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const folderInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -302,13 +298,6 @@ export function AddSourceDialog({ notebookId, open, onOpenChange }: AddSourceDia
   };
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? []);
-    e.target.value = "";
-    if (files.length === 0) return;
-    handleFilesUpload(files);
-  };
-
-  const handleFolderSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
     e.target.value = "";
     if (files.length === 0) return;
@@ -687,9 +676,11 @@ export function AddSourceDialog({ notebookId, open, onOpenChange }: AddSourceDia
                   }}
                 >
                   <p className="text-lg text-muted-foreground">
-                    or drop your files or folders
+                    Drop files or a folder here
                   </p>
-                  <p className="text-xs text-muted-foreground mt-1">pdf, docx, txt, md</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    or click Upload — pdf, docx, txt, md
+                  </p>
                 </div>
                 <input
                   ref={fileInputRef}
@@ -699,15 +690,6 @@ export function AddSourceDialog({ notebookId, open, onOpenChange }: AddSourceDia
                   className="hidden"
                   accept=".pdf,.docx,.doc,.pptx,.ppt,.txt,.md"
                   onChange={handleFileSelect}
-                />
-                <input
-                  ref={folderInputRef}
-                  type="file"
-                  multiple
-                  // webkitdirectory is not in React's typed prop set; pass as string.
-                  {...({ webkitdirectory: "", directory: "" } as Record<string, string>)}
-                  className="hidden"
-                  onChange={handleFolderSelect}
                 />
 
                 {uploadError && (
@@ -724,50 +706,14 @@ export function AddSourceDialog({ notebookId, open, onOpenChange }: AddSourceDia
 
                 {/* Bottom Actions */}
                 <div className="grid grid-cols-2 gap-2.5 px-6 pb-6">
-                  <Popover open={isUploadMenuOpen} onOpenChange={setIsUploadMenuOpen}>
-                    <PopoverTrigger asChild>
-                      <button
-                        disabled={isLimitReached}
-                        className="flex items-center justify-center gap-2 py-3 border border-border rounded-xl text-sm font-medium hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        <Upload className="h-4 w-4" />
-                        Upload
-                        <ChevronDown className="h-3 w-3 text-muted-foreground" />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-56 p-1" align="start">
-                      <button
-                        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left hover:bg-accent/30 transition-colors"
-                        onClick={() => {
-                          setIsUploadMenuOpen(false);
-                          fileInputRef.current?.click();
-                        }}
-                      >
-                        <FileText className="h-5 w-5 shrink-0" />
-                        <div>
-                          <div className="text-sm font-semibold">Files</div>
-                          <div className="text-xs text-muted-foreground">
-                            Pick one or multiple files
-                          </div>
-                        </div>
-                      </button>
-                      <button
-                        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-left hover:bg-accent/30 transition-colors"
-                        onClick={() => {
-                          setIsUploadMenuOpen(false);
-                          folderInputRef.current?.click();
-                        }}
-                      >
-                        <Folder className="h-5 w-5 shrink-0" />
-                        <div>
-                          <div className="text-sm font-semibold">Folder</div>
-                          <div className="text-xs text-muted-foreground">
-                            Upload every file in a folder
-                          </div>
-                        </div>
-                      </button>
-                    </PopoverContent>
-                  </Popover>
+                  <button
+                    disabled={isLimitReached}
+                    className="flex items-center justify-center gap-2 py-3 border border-border rounded-xl text-sm font-medium hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <Upload className="h-4 w-4" />
+                    Upload
+                  </button>
                   <button
                     disabled={isLimitReached}
                     className="flex items-center justify-center gap-2 py-3 border border-border rounded-xl text-sm font-medium hover:bg-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
…drop

Drops the previous Upload / Folder dropdown in favor of a single Upload button that opens the multi-file picker (one or many files). Folder uploads continue to work via drag-and-drop onto the dropzone, which the existing DataTransfer walker already handles. Dropzone copy updated to surface the DnD affordance.