### PR TITLE
fix(web): proxy LangGraph through same-origin /api/langgraph

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -39,10 +39,13 @@ INGEST_PER_USER_CONCURRENCY=2
 # =============================================
 # 3. Backend Services
 # =============================================
-# LangGraph Agent (must be reachable from both server and browser).
+# LangGraph Agent. Only needs to be reachable from the Next.js server —
+# the browser talks to /api/langgraph (same-origin reverse proxy).
 # Hosts the notebook, hub, and deep_research surface graphs.
 LANGGRAPH_API_URL=http://localhost:2024
-NEXT_PUBLIC_LANGGRAPH_API_URL=http://localhost:2024
+# Deprecated: kept only as a fallback when LANGGRAPH_API_URL is unset.
+# Safe to remove in production once LANGGRAPH_API_URL is configured.
+# NEXT_PUBLIC_LANGGRAPH_API_URL=http://localhost:2024
 
 # Workflows server (apps/agent FastAPI).
 # Hosts /v1/workflows/search, /v1/workflows/matcher/jobs/*,

--- a/apps/web/app/api/chat/[sessionId]/route.ts
+++ b/apps/web/app/api/chat/[sessionId]/route.ts
@@ -7,7 +7,11 @@ interface RouteParams {
 }
 
 function getLangGraphApiUrl(): string | null {
-  return process.env.NEXT_PUBLIC_LANGGRAPH_API_URL || null;
+  return (
+    process.env.LANGGRAPH_API_URL ||
+    process.env.NEXT_PUBLIC_LANGGRAPH_API_URL ||
+    null
+  );
 }
 
 export async function GET(req: NextRequest, { params }: RouteParams) {
@@ -115,7 +119,7 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
         });
       } else {
         console.warn(
-          "Skipping agent memory cleanup because NEXT_PUBLIC_LANGGRAPH_API_URL is not configured.",
+          "Skipping agent memory cleanup because LANGGRAPH_API_URL is not configured.",
         );
       }
     } catch (agentError) {

--- a/apps/web/app/api/langgraph/[...path]/route.ts
+++ b/apps/web/app/api/langgraph/[...path]/route.ts
@@ -1,0 +1,101 @@
+import { auth } from "@/lib/auth";
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const fetchCache = "force-no-store";
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+  "accept-encoding",
+]);
+
+function getUpstreamBaseUrl(): string | null {
+  const url =
+    process.env.LANGGRAPH_API_URL ??
+    process.env.NEXT_PUBLIC_LANGGRAPH_API_URL ??
+    null;
+  if (!url) return null;
+  return url.replace(/\/+$/, "");
+}
+
+async function proxy(
+  req: NextRequest,
+  ctx: { params: Promise<{ path?: string[] }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const upstreamBase = getUpstreamBaseUrl();
+  if (!upstreamBase) {
+    return new Response(
+      "LANGGRAPH_API_URL is not configured on the server.",
+      { status: 500 },
+    );
+  }
+
+  const { path } = await ctx.params;
+  const subPath = (path ?? []).map(encodeURIComponent).join("/");
+  const search = new URL(req.url).search;
+  const target = `${upstreamBase}/${subPath}${search}`;
+
+  const headers = new Headers();
+  req.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+
+  const hasBody = req.method !== "GET" && req.method !== "HEAD";
+  const init: RequestInit & { duplex?: "half" } = {
+    method: req.method,
+    headers,
+    body: hasBody ? req.body : undefined,
+    redirect: "manual",
+    cache: "no-store",
+  };
+  if (hasBody) init.duplex = "half";
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, init);
+  } catch (err) {
+    console.error("[langgraph proxy] upstream fetch failed:", err);
+    return new Response(
+      "Failed to reach LangGraph upstream. Check server LANGGRAPH_API_URL and that the agent is running.",
+      { status: 502 },
+    );
+  }
+
+  const responseHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      responseHeaders.set(key, value);
+    }
+  });
+  responseHeaders.set("X-Accel-Buffering", "no");
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;
+export const OPTIONS = proxy;

--- a/apps/web/components/deepdive/chat/chat-panel.tsx
+++ b/apps/web/components/deepdive/chat/chat-panel.tsx
@@ -59,7 +59,9 @@ interface ModelSettings {
   modelName: string;
 }
 
-const LANGGRAPH_API_URL = process.env.NEXT_PUBLIC_LANGGRAPH_API_URL;
+// Same-origin reverse proxy at app/api/langgraph/[...path]/route.ts.
+// Avoids CORS, mixed-content, and reachability issues for end users.
+const LANGGRAPH_API_URL = "/api/langgraph";
 
 // Spark-diamond glyph from Sparkflow Design System (brand lockup).
 function SparkDiamond({ className = "h-3.5 w-3.5" }: { className?: string }) {
@@ -84,12 +86,6 @@ export function ChatPanel({
   onWikiNavigate,
   onNoteAdded,
 }: ChatPanelProps) {
-  if (!LANGGRAPH_API_URL) {
-    throw new Error(
-      "NEXT_PUBLIC_LANGGRAPH_API_URL is not configured. Set it to the reachable LangGraph server URL.",
-    );
-  }
-
   // Thread management
   const [threadId, setThreadId] = useState<string | null>(
     initialSessions.length > 0 ? initialSessions[0].langgraphThreadId || null : null,

--- a/apps/web/components/explore/explore-shell.tsx
+++ b/apps/web/components/explore/explore-shell.tsx
@@ -13,8 +13,9 @@ import {
 import { HubToolUIs } from "./research-assistant-tools";
 import { AIContextProvider, useAIContext } from "./ai-context";
 
+// Same-origin reverse proxy at app/api/langgraph/[...path]/route.ts.
 const langGraphClient = new Client({
-  apiUrl: process.env.NEXT_PUBLIC_LANGGRAPH_API_URL ?? "http://localhost:2024",
+  apiUrl: "/api/langgraph",
   apiKey: null,
 });
 


### PR DESCRIPTION
The browser used to connect directly to NEXT_PUBLIC_LANGGRAPH_API_URL, which made notebook chat fail with "Failed to fetch" for any user whose network couldn't reach that URL (mixed content, CORS, localhost in prod bundle, firewalls). Add an auth-gated streaming reverse proxy at app/api/langgraph/[...path] and point both the deepdive chat panel (useStream) and the explore-shell Client at /api/langgraph. LangGraph now only needs to be reachable from the Next.js server.