### PR TITLE
fix(web): build absolute LangGraph apiUrl from window.location.origin

### DIFF
--- a/apps/web/components/deepdive/chat/chat-panel.tsx
+++ b/apps/web/components/deepdive/chat/chat-panel.tsx
@@ -61,7 +61,15 @@ interface ModelSettings {
 
 // Same-origin reverse proxy at app/api/langgraph/[...path]/route.ts.
 // Avoids CORS, mixed-content, and reachability issues for end users.
-const LANGGRAPH_API_URL = "/api/langgraph";
+// Must be an absolute URL because the LangGraph SDK uses `new URL(apiUrl + path)`.
+function getLangGraphApiUrl(): string {
+  if (typeof window === "undefined") {
+    // SSR fallback — useStream only runs on the client, but the const must
+    // resolve to *something* during render to avoid passing undefined.
+    return "http://localhost/api/langgraph";
+  }
+  return `${window.location.origin}/api/langgraph`;
+}
 
 // Spark-diamond glyph from Sparkflow Design System (brand lockup).
 function SparkDiamond({ className = "h-3.5 w-3.5" }: { className?: string }) {
@@ -178,7 +186,7 @@ export function ChatPanel({
 
   // LangGraph stream hook - model selection happens per-request via context
   const stream = useStream<AgentState>({
-    apiUrl: LANGGRAPH_API_URL,
+    apiUrl: getLangGraphApiUrl(),
     assistantId: "notebook",
     threadId: threadId ?? undefined,
     onThreadId: (newThreadId) => {

--- a/apps/web/components/explore/explore-shell.tsx
+++ b/apps/web/components/explore/explore-shell.tsx
@@ -14,10 +14,16 @@ import { HubToolUIs } from "./research-assistant-tools";
 import { AIContextProvider, useAIContext } from "./ai-context";
 
 // Same-origin reverse proxy at app/api/langgraph/[...path]/route.ts.
-const langGraphClient = new Client({
-  apiUrl: "/api/langgraph",
-  apiKey: null,
-});
+// The SDK's `new URL(apiUrl + path)` requires an absolute URL, so we resolve
+// against window.location.origin at runtime (the Client is only used in the
+// browser). Module-level `new Client(...)` would crash during SSR.
+function buildLangGraphClient(): Client {
+  const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost";
+  return new Client({
+    apiUrl: `${origin}/api/langgraph`,
+    apiKey: null,
+  });
+}
 
 export interface ExploreShellProps {
   children: React.ReactNode;
@@ -78,6 +84,11 @@ function ExploreShellInner({ children, user }: ExploreShellProps) {
   const [assistantOpen, setAssistantOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const exploreNavLinks = useExploreNavLinks();
+  // Lazy state initializer runs once per mount; on the client `window` is
+  // defined so the Client gets a valid absolute apiUrl. During SSR this
+  // returns a placeholder Client that is never actually invoked because the
+  // runtime calls only fire from event handlers / effects.
+  const [langGraphClient] = useState<Client>(() => buildLangGraphClient());
 
   // Build page context string from AI context
   const pageContext = useMemo(() => {


### PR DESCRIPTION
The previous commit set apiUrl to "/api/langgraph", but the LangGraph SDK does new URL(apiUrl + path) internally, which throws on a relative URL — so no request was ever sent to the proxy. Resolve the proxy URL against window.location.origin at runtime in both the deepdive chat panel and the explore-shell hub client. SSR is handled with a safe fallback since the SDK only fires from event handlers and effects.