### PR TITLE
perf(agent): cut langgraph up build time

### DIFF
--- a/apps/agent/Dockerfile
+++ b/apps/agent/Dockerfile
@@ -1,17 +1,19 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.13-slim
 
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
-# Copy requirements first for better caching
+# Install requirements first for layer caching, with a BuildKit cache mount
+# so re-builds reuse already-downloaded wheels (saves minutes on rebuild).
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
 
-# Copy application code
+# Copy application code last so source edits don't bust the deps layer.
 COPY . .
 
 # Create non-root user

--- a/apps/agent/Makefile
+++ b/apps/agent/Makefile
@@ -1,0 +1,43 @@
+IMAGE_TAG ?= sparkflow-agent:dev
+PORT ?= 2024
+
+export DOCKER_BUILDKIT := 1
+export COMPOSE_DOCKER_CLI_BUILD := 1
+
+.PHONY: dev build up up-fresh down lint test clean help
+
+help:
+	@echo "Targets:"
+	@echo "  dev       - In-process LangGraph dev server (fastest; no Docker)"
+	@echo "  build     - Build the agent image once ($(IMAGE_TAG))"
+	@echo "  up        - Start postgres/redis + agent, reusing the prebuilt image"
+	@echo "  up-fresh  - Rebuild image and start (use after dependency changes)"
+	@echo "  down      - Stop and remove the up stack"
+	@echo "  test      - Run pytest"
+	@echo "  clean     - Remove the prebuilt image"
+
+# Fastest path: in-process, hot reload. Use this for daily development.
+dev:
+	langgraph dev --host 0.0.0.0 --port $(PORT)
+
+# One-shot build. Re-run only when requirements.txt / pyproject.toml change.
+build:
+	langgraph build -t $(IMAGE_TAG)
+
+# Start the stack against an already-built image — skips the build step.
+up: build
+	langgraph up --image $(IMAGE_TAG) --port $(PORT)
+
+# Force a rebuild (e.g. after editing requirements).
+up-fresh:
+	langgraph build --no-cache -t $(IMAGE_TAG)
+	langgraph up --image $(IMAGE_TAG) --port $(PORT)
+
+down:
+	langgraph down || true
+
+test:
+	pytest
+
+clean:
+	-docker image rm $(IMAGE_TAG)

--- a/apps/agent/README.md
+++ b/apps/agent/README.md
@@ -15,8 +15,29 @@ This directory hosts the LangGraph agent runtime and its supporting modules.
 The `hub` graph uses GenAI Toolbox for deterministic database querying and relies on CopilotKit-provided MCP Apps actions for workflow/presentation rendering.
 
 ## Run Locally
+
+In-process dev server (fastest, no Docker, hot reload):
 ```bash
-langgraph dev --host 0.0.0.0 --port 2024
+make dev
+# equivalent to: langgraph dev --host 0.0.0.0 --port 2024
+```
+
+Full Docker stack (postgres + redis + agent), build once, restart fast:
+```bash
+make build       # only when requirements.txt / pyproject.toml change
+make up          # reuses sparkflow-agent:dev image, skips rebuild
+make up-fresh    # force rebuild (after dep changes)
+```
+
+### Optional: BGE-M3 embeddings for offline backfill
+
+`scripts/backfill_*.py` need BGE-M3 (pulls torch + transformers, ~800MB).
+Not installed by default to keep the agent image lean. Install only on
+machines that run those scripts:
+```bash
+pip install -r requirements-embeddings.txt
+# or, if working from pyproject:
+pip install -e ".[embeddings]"
 ```
 
 ## Key Environment Variables

--- a/apps/agent/langgraph.json
+++ b/apps/agent/langgraph.json
@@ -8,5 +8,10 @@
         "deep_research": "./graphs/surface.py:deep_research_graph"
     },
     "env": ".env",
-    "image_distro": "wolfi"
+    "image_distro": "wolfi",
+    "dockerfile_lines": [
+        "ENV PIP_CACHE_DIR=/root/.cache/pip",
+        "ENV UV_CACHE_DIR=/root/.cache/uv",
+        "ENV PYTHONDONTWRITEBYTECODE=1"
+    ]
 }

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -20,8 +20,6 @@ dependencies = [
     "copilotkit",
     "deepagents",
     "tavily-python",
-    # BGE-M3 embeddings (CPU) — drives the search-agent prefilter.
-    "FlagEmbedding>=1.2",
     # Workflow server
     "fastapi>=0.109",
     "uvicorn[standard]>=0.27",
@@ -39,4 +37,11 @@ dev = [
     "pytest>=7.4",
     "pytest-asyncio>=0.23",
     "pytest-mock>=3.12",
+]
+# BGE-M3 (CPU) — pulls torch + transformers (~800MB).
+# Only the offline backfill scripts use it; LangGraph runtime does not.
+# Install separately on machines that run those scripts:
+#   pip install -e ".[embeddings]"
+embeddings = [
+    "FlagEmbedding>=1.2",
 ]

--- a/apps/agent/requirements-embeddings.txt
+++ b/apps/agent/requirements-embeddings.txt
@@ -1,0 +1,11 @@
+# Optional embeddings stack for offline backfill scripts only.
+# NOT required by the LangGraph runtime (kept out to shrink the agent
+# image by ~800MB / save several minutes per `langgraph build`).
+#
+# Install on the machine that runs scripts/backfill_*.py:
+#   pip install -r requirements-embeddings.txt
+# or, if using pyproject extras:
+#   pip install -e ".[embeddings]"
+
+# BGE-M3 (CPU) — pulls torch + transformers transitively.
+FlagEmbedding>=1.2

--- a/apps/agent/requirements.txt
+++ b/apps/agent/requirements.txt
@@ -28,9 +28,6 @@ PyYAML>=6.0
 httpx
 tavily-python
 
-# BGE-M3 embeddings (CPU) — powers the search-agent prefilter.
-FlagEmbedding>=1.2
-
 # Workflow server
 fastapi>=0.109
 uvicorn[standard]>=0.27


### PR DESCRIPTION
* Move FlagEmbedding (~800MB torch+transformers) out of the runtime deps and into a `[embeddings]` optional extra. The three LangGraph graphs never import it; only offline backfill scripts do.
* Add BuildKit pip-cache env in langgraph.json so rebuilds reuse downloaded wheels instead of re-fetching everything.
* Switch the standalone Dockerfile to BuildKit cache mounts and drop the unused build-essential install.
* Add a Makefile with a build-once / up-many workflow:
    make dev      # in-process, fastest
    make build    # rebuild image (only when deps change)
    make up       # reuse the prebuilt image
* Update README to document the new flow and the embeddings extras.