### PR TITLE
fix(docker): restore digest-worker build + correct in-container URLs

### DIFF
--- a/apps/agent/Dockerfile.worker
+++ b/apps/agent/Dockerfile.worker
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.7
+# Digest worker image — runs `arq workflows.digest_worker.WorkerSettings`.
+# Separate from langgraph-api (which builds its own image via `langgraph build`
+# from langgraph.json). The worker calls back to apps/web over HTTP, so it does
+# NOT need langchain/langgraph/openai — only arq + httpx.
+
+FROM python:3.13-slim
+
+WORKDIR /app
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install "arq>=0.25" "httpx" "python-dotenv"
+
+COPY workflows ./workflows
+
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+USER appuser
+
+CMD ["arq", "workflows.digest_worker.WorkerSettings"]

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -45,8 +45,10 @@ services:
     command: ["npm", "run", "worker:ingest"]
     env_file: .env
     environment:
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
-      DATABASE_URL: ${DATABASE_URL}
+      # Override host-side localhost URLs with docker service hostnames.
+      # apps/web/.env uses localhost so `npm run dev` works on the host.
+      REDIS_URL: redis://redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:-sparkflow}:${POSTGRES_PASSWORD:-sparkflow}@postgres:5432/${POSTGRES_DB:-sparkflow}
     depends_on:
       postgres:
         condition: service_healthy
@@ -57,12 +59,13 @@ services:
   digest-worker:
     build:
       context: ../agent
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.worker
     container_name: sparkflow-digest-worker
     command: ["arq", "workflows.digest_worker.WorkerSettings"]
     env_file: ../agent/.env
     environment:
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      # Override host-side localhost URL with docker service hostname.
+      REDIS_URL: redis://redis:6379
       SPARKFLOW_API_URL: ${SPARKFLOW_API_URL}
       SEMOPS_API_URL: ${SEMOPS_API_URL}
       INTERNAL_CALLBACK_TOKEN: ${INTERNAL_CALLBACK_TOKEN}


### PR DESCRIPTION
* Add apps/agent/Dockerfile.worker. Commit 8c73523 deleted apps/agent/Dockerfile as "unused", but apps/web/docker-compose.yml's digest-worker service was building from it. The new Dockerfile.worker installs only what the worker actually imports (arq + httpx + python-dotenv) and copies workflows/ — langchain/langgraph aren't needed since the worker calls back to apps/web over HTTP. Build drops from minutes of pip backtracking to ~3s.

* Hardcode docker service hostnames in both worker environment blocks. ${REDIS_URL:-redis://redis:6379} was being filled at compose-time from apps/web/.env (REDIS_URL=redis://localhost:6379 — correct for host-side `npm run dev`), so containers got localhost and could not reach redis. Same root cause for ingest-worker's DATABASE_URL.