### PR TITLE
fix(docker): pass --ignore-scripts to npm ci to dodge npm 11 crash

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -16,8 +16,13 @@ COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 COPY prisma.config.ts ./
 
-# Install dependencies and generate Prisma client
-RUN npm ci && npx prisma generate
+# Install dependencies and generate Prisma client.
+# --ignore-scripts skips package postinstall hooks during install — most
+# importantly Prisma's engine-binary download, which can hang/segfault
+# and trigger npm 11's "Exit handler never called!" bug. We run
+# `prisma generate` explicitly afterwards so the client still lands in
+# node_modules/.prisma.
+RUN npm ci --ignore-scripts && npx prisma generate
 
 COPY . .
 

--- a/apps/web/Dockerfile.worker
+++ b/apps/web/Dockerfile.worker
@@ -10,7 +10,12 @@ FROM base AS deps
 ENV NODE_TLS_REJECT_UNAUTHORIZED=0
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
-RUN npm ci && npx prisma generate
+# --ignore-scripts skips all package postinstall hooks during install.
+# Without this, Prisma's postinstall (which downloads engine binaries)
+# can hang/segfault and trigger npm 11's "Exit handler never called!"
+# bug. We then run `prisma generate` explicitly so the engine + client
+# end up in node_modules/.prisma the same as before.
+RUN npm ci --ignore-scripts && npx prisma generate
 
 FROM base AS runtime
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
`npm ci` on node:24 (npm 11) crashes with `Exit handler never called!` when one of the dependencies' postinstall scripts misbehaves — most commonly Prisma's engine-binary download, which can hang or segfault inside the build sandbox.

Skipping all postinstall hooks via --ignore-scripts removes the trigger; we then run `npx prisma generate` explicitly afterwards so node_modules/.prisma still ends up populated. Other postinstall scripts in the dep tree (sharp, esbuild, etc.) ship prebuilt binaries via optionalDependencies, so the worker / web runtime is unaffected.

Apply to both apps/web/Dockerfile and apps/web/Dockerfile.worker since they share the same install pattern.