### PR TITLE
fix(docker): support optional corporate CA bundle in image builds

### DIFF
--- a/apps/agent/Dockerfile.worker
+++ b/apps/agent/Dockerfile.worker
@@ -12,6 +12,18 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+# Optional corporate CA bundle (see Dockerfile.workflows-api for context).
+# File MUST exist; empty = no-op for open networks.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+COPY ca-certificates.crt /tmp/corporate-ca.crt
+RUN if [ -s /tmp/corporate-ca.crt ]; then \
+      cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
+      update-ca-certificates; \
+    fi && rm /tmp/corporate-ca.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install "arq>=0.25" "httpx" "python-dotenv"
 

--- a/apps/agent/Dockerfile.workflows-api
+++ b/apps/agent/Dockerfile.workflows-api
@@ -13,6 +13,20 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+# Optional corporate CA bundle for HTTPS-intercepting proxies.
+# python:3.13-slim doesn't ship `ca-certificates` so we install it
+# first; on networks that don't need a CA the file is empty and the
+# install no-ops. File MUST exist (gitignored — see apps/agent/.gitignore).
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+COPY ca-certificates.crt /tmp/corporate-ca.crt
+RUN if [ -s /tmp/corporate-ca.crt ]; then \
+      cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
+      update-ca-certificates; \
+    fi && rm /tmp/corporate-ca.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 # Install runtime deps from pyproject.toml. Using `uv` instead of plain
 # `pip` because pyproject.toml leaves langchain/langgraph/langchain-* on
 # their floating ranges — pip's resolver backtracks for many minutes,

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -34,6 +34,10 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env
 
+# Corporate CA bundle for HTTPS-intercepting proxies. Drop the cert
+# here on machines that need it; never commit.
+ca-certificates.crt
+
 # vercel
 .vercel
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -12,6 +12,15 @@ ENV NODE_TLS_REJECT_UNAUTHORIZED=0
 # Real DATABASE_URL is supplied at runtime; this placeholder is build-only.
 ENV DATABASE_URL=postgresql://placeholder:placeholder@localhost:5432/placeholder
 
+# Optional corporate CA bundle. See Dockerfile.worker for details.
+# File `apps/web/ca-certificates.crt` MUST exist (empty is fine).
+COPY ca-certificates.crt /tmp/corporate-ca.crt
+RUN if [ -s /tmp/corporate-ca.crt ]; then \
+      cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
+      update-ca-certificates; \
+    fi && rm /tmp/corporate-ca.crt
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 COPY prisma.config.ts ./

--- a/apps/web/Dockerfile.worker
+++ b/apps/web/Dockerfile.worker
@@ -6,8 +6,20 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 FROM base AS deps
-# Skip SSL verification matches the pattern in the main Dockerfile.
 ENV NODE_TLS_REJECT_UNAUTHORIZED=0
+# Optional corporate CA bundle. Required on networks whose proxy does
+# TLS interception (registry calls would otherwise fail with "sslv3
+# alert handshake failure"). The file `apps/web/ca-certificates.crt`
+# MUST exist; gitignored — populate with your CA on networks that need
+# it, otherwise leave empty. The RUN below installs it only when
+# non-empty so open-network builds are unaffected.
+COPY ca-certificates.crt /tmp/corporate-ca.crt
+RUN if [ -s /tmp/corporate-ca.crt ]; then \
+      cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
+      update-ca-certificates; \
+    fi && rm /tmp/corporate-ca.crt
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 # Use pnpm via corepack instead of `npm ci`. npm 11 (shipped with


### PR DESCRIPTION
Networks with HTTPS-intercepting proxies (e.g. internal Huawei dev proxy at 10.218.x.x:3128) present their own CA on every TLS request. Without that CA in the container's trust store every npm/pnpm/uv/pip fetch fails with "sslv3 alert handshake failure" — which manifests as the npm 11 "Exit handler never called!" crash after a long retry loop, or as a fast SSL handshake failure under uv.

Each Dockerfile now expects a `ca-certificates.crt` file at the build context root. If the file has content it's installed into the system trust store via `update-ca-certificates`; if it's empty (open networks) the install no-ops. The file is gitignored so the cert never lands in git or in a publicly-pushed image.

* apps/web/Dockerfile, apps/web/Dockerfile.worker: COPY + conditional install + NODE_EXTRA_CA_CERTS pointing at the merged bundle.
* apps/agent/Dockerfile.worker, Dockerfile.workflows-api: same pattern, plus an `apt-get install ca-certificates` first because python:3.13-slim doesn't ship the package by default. Sets SSL_CERT_FILE + REQUESTS_CA_BUNDLE for httpx/requests/openai SDK.
* apps/web/.gitignore: ignore ca-certificates.crt (apps/agent/.gitignore already had it).

Setup on machines that need this: put the corporate CA at apps/web/ca-certificates.crt and apps/agent/ca-certificates.crt. Open-network setup: `touch apps/web/ca-certificates.crt apps/agent/ca-certificates.crt` (the empty-file path).