### PR TITLE
chore(docker): revert pnpm workaround now that the CA fix is in place

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /app
 # Builder stage
 FROM base AS builder
 
-# Skip SSL verification for npm/prisma during build
-ENV NODE_TLS_REJECT_UNAUTHORIZED=0
 # prisma.config.ts eagerly reads DATABASE_URL on load. `prisma generate`
 # doesn't actually need a live DB, but the config loader resolves env first.
 # Real DATABASE_URL is supplied at runtime; this placeholder is build-only.
@@ -25,12 +23,7 @@ COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 COPY prisma.config.ts ./
 
-# Use pnpm via corepack instead of `npm ci`. npm 11 (shipped with
-# node:24) crashes mid-install with "Exit handler never called!" on
-# this lockfile; pnpm's installer is a different code path and is also
-# 3-5× faster on cold caches.
-RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN pnpm install --no-frozen-lockfile --ignore-scripts && pnpm exec prisma generate
+RUN npm ci && npx prisma generate
 
 COPY . .
 

--- a/apps/web/Dockerfile.worker
+++ b/apps/web/Dockerfile.worker
@@ -6,7 +6,6 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 FROM base AS deps
-ENV NODE_TLS_REJECT_UNAUTHORIZED=0
 # Optional corporate CA bundle. Required on networks whose proxy does
 # TLS interception (registry calls would otherwise fail with "sslv3
 # alert handshake failure"). The file `apps/web/ca-certificates.crt`
@@ -22,14 +21,7 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
-# Use pnpm via corepack instead of `npm ci`. npm 11 (shipped with
-# node:24) reliably crashes mid-install with "Exit handler never
-# called!" on this lockfile — even with --ignore-scripts and a 4GB
-# heap. pnpm's installer is a different code path entirely and is also
-# 3-5× faster on cold caches. --no-frozen-lockfile lets pnpm install
-# from package.json without needing to commit a pnpm-lock.yaml.
-RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN pnpm install --no-frozen-lockfile --ignore-scripts && pnpm exec prisma generate
+RUN npm ci && npx prisma generate
 
 FROM base AS runtime
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
The pnpm switch was a workaround for what looked like a npm 11 bug ("Exit handler never called!"). The actual cause was the TLS-intercepting corporate proxy + missing CA bundle in the image — npm was just retrying a doomed TLS handshake until it crashed itself. With ca-certificates.crt now baked in via the previous commit, plain `npm ci` works cleanly again.

Drop:
* corepack enable / pnpm install
* --ignore-scripts (Prisma's postinstall now reaches the registry)
* NODE_TLS_REJECT_UNAUTHORIZED=0 (CA in the trust store makes this unnecessary and dangerous)

Restored to the original `RUN npm ci && npx prisma generate`.