### PR TITLE
docs(env): use current LangSmith env var names

### DIFF
--- a/apps/agent/.env.example
+++ b/apps/agent/.env.example
@@ -63,8 +63,13 @@ WECHAT_DATABASE_URL=
 DIGEST_WORKER_CONCURRENCY=4
 
 # ---------------------------------------------------------------------------
-# Observability (optional)
+# Observability — LangSmith tracing (optional)
 # ---------------------------------------------------------------------------
-# LangSmith tracing requires BOTH variables — the API key alone is silent.
-# LANGCHAIN_TRACING_V2=true
-# LANGSMITH_API_KEY=
+# All four are needed for traces to land in the right project. The API
+# key alone is silent without LANGSMITH_TRACING. Uncomment to enable.
+# LANGSMITH_TRACING=true
+# LANGSMITH_API_KEY=lsv2_pt_xxxxxxxxxxxxxxxx
+# LANGSMITH_PROJECT=sparkflow-agent
+# Set when behind a TLS-intercepting corporate proxy and your CA isn't
+# trusted by langgraph's outbound calls; off in normal dev.
+# LANGGRAPH_DISABLE_SSL_VERIFY=1

--- a/apps/agent/.env.production.example
+++ b/apps/agent/.env.production.example
@@ -72,7 +72,11 @@ WECHAT_DATABASE_URL=
 DIGEST_WORKER_CONCURRENCY=4
 
 # ---------------------------------------------------------------------------
-# Observability — recommended in production
+# Observability — LangSmith tracing (recommended in production)
 # ---------------------------------------------------------------------------
-LANGCHAIN_TRACING_V2=true
+LANGSMITH_TRACING=true
 LANGSMITH_API_KEY=__your_langsmith_key__
+LANGSMITH_PROJECT=sparkflow-agent
+# Set on hosts behind a TLS-intercepting proxy whose CA isn't trusted
+# by langgraph's outbound https calls. Leave commented otherwise.
+# LANGGRAPH_DISABLE_SSL_VERIFY=1


### PR DESCRIPTION
The LANGCHAIN_TRACING_V2 / LANGSMITH_API_KEY combo is the legacy form (still works on most SDK versions but deprecated). Replace with the LangSmith-native names that newer langchain / langgraph releases expect, and add the project name + the SSL bypass flag for hosts behind TLS-intercepting corporate proxies.

* LANGSMITH_TRACING=true (was LANGCHAIN_TRACING_V2)
* LANGSMITH_API_KEY (unchanged)
* LANGSMITH_PROJECT=sparkflow-agent (new — without it traces land in the default project bucket)
* LANGGRAPH_DISABLE_SSL_VERIFY=1 (new, optional — for hosts on the Huawei-style proxy where api.smith.langchain.com goes through TLS interception)

Both apps/agent/.env.example and .env.production.example updated.