### PR TITLE
fix(ingest): route wiki ingest through the queue from every source path

### DIFF
--- a/apps/web/lib/actions/sources.ts
+++ b/apps/web/lib/actions/sources.ts
@@ -329,12 +329,17 @@ export async function addWechatSource(notebookId: string, articleId: number) {
         },
       });
 
-      // Trigger wiki ingest
+      // Enqueue wiki ingest — drained out-of-process by ingest-worker.
       try {
-        const { ingestSourceToWiki } = await import("@/lib/services/wiki-ingest");
-        await ingestSourceToWiki(notebookId, source.id, session.user.id);
+        const { enqueueWikiIngest } = await import("@/lib/queue/ingest-queue");
+        const { jobId } = await enqueueWikiIngest({
+          notebookId,
+          sourceId: source.id,
+          userId: session.user.id,
+        });
+        console.log(`[addWechatSource] wiki ingest enqueued: ${jobId}`);
       } catch (wikiErr) {
-        console.error("[addWechatSource] Wiki ingest failed:", wikiErr);
+        console.error("[addWechatSource] Failed to enqueue wiki ingest:", wikiErr);
       }
     } catch (err) {
       console.error("[addWechatSource] Failed:", err);

--- a/apps/web/lib/services/source-processors/mineru-processor.ts
+++ b/apps/web/lib/services/source-processors/mineru-processor.ts
@@ -78,11 +78,15 @@ export async function processMineruDocument(
     });
 
     try {
-      const { ingestSourceToWiki } = await import("@/lib/services/wiki-ingest");
-      const result = await ingestSourceToWiki(context.notebookId, sourceId, context.userId);
-      console.log(`Wiki ingest complete: ${result.pagesWritten} pages written`);
+      const { enqueueWikiIngest } = await import("@/lib/queue/ingest-queue");
+      const { jobId } = await enqueueWikiIngest({
+        notebookId: context.notebookId,
+        sourceId,
+        userId: context.userId,
+      });
+      console.log(`[mineru-processor] wiki ingest enqueued: ${jobId}`);
     } catch (err) {
-      console.error("Wiki ingest failed:", err);
+      console.error("[mineru-processor] failed to enqueue wiki ingest:", err);
     }
 
     return { success: true };

--- a/apps/web/lib/services/source-processors/text-processor.ts
+++ b/apps/web/lib/services/source-processors/text-processor.ts
@@ -30,14 +30,17 @@ export async function processTextDocument(
       },
     });
 
-    // Trigger wiki ingest (awaited to prevent premature termination)
+    // Enqueue wiki ingest — drained out-of-process by ingest-worker.
     try {
-      const { ingestSourceToWiki } = await import("@/lib/services/wiki-ingest");
-      const result = await ingestSourceToWiki(context.notebookId, sourceId, context.userId);
-      console.log(`Wiki ingest complete: ${result.pagesWritten} pages written`);
+      const { enqueueWikiIngest } = await import("@/lib/queue/ingest-queue");
+      const { jobId } = await enqueueWikiIngest({
+        notebookId: context.notebookId,
+        sourceId,
+        userId: context.userId,
+      });
+      console.log(`[text-processor] wiki ingest enqueued: ${jobId}`);
     } catch (err) {
-      console.error("Wiki ingest failed:", err);
-      // Don't fail the source processing if wiki ingest fails
+      console.error("[text-processor] failed to enqueue wiki ingest:", err);
     }
 
     return { success: true };

--- a/apps/web/lib/services/source-processors/webpage-processor.ts
+++ b/apps/web/lib/services/source-processors/webpage-processor.ts
@@ -64,13 +64,17 @@ export async function processWebpage(
       },
     });
 
-    // Trigger wiki ingest (awaited to prevent premature termination)
+    // Enqueue wiki ingest — drained out-of-process by ingest-worker.
     try {
-      const { ingestSourceToWiki } = await import("@/lib/services/wiki-ingest");
-      const ingestResult = await ingestSourceToWiki(context.notebookId, sourceId, context.userId);
-      console.log(`Wiki ingest complete: ${ingestResult.pagesWritten} pages written`);
+      const { enqueueWikiIngest } = await import("@/lib/queue/ingest-queue");
+      const { jobId } = await enqueueWikiIngest({
+        notebookId: context.notebookId,
+        sourceId,
+        userId: context.userId,
+      });
+      console.log(`[webpage-processor] wiki ingest enqueued: ${jobId}`);
     } catch (err) {
-      console.error("Wiki ingest failed:", err);
+      console.error("[webpage-processor] failed to enqueue wiki ingest:", err);
     }
 
     return { success: true };


### PR DESCRIPTION
Two parallel call paths existed for wiki ingest:
  • POST /api/notebooks/[id]/sources → enqueueWikiIngest (correct)
  • Server actions for PDF/text/webpage/wechat → processFooDocument →
    ingestSourceToWiki INLINE inside the web request

The second path blocked the upload HTTP request for as long as the graph-extraction LLM call took. On slow networks / corporate proxies this now hits the OpenAI client's 10-minute timeout and surfaces as "Wiki ingest failed: Request timed out" with no visibility — the ingest-worker shows nothing because no job was ever enqueued.

Replace the four inline call sites with enqueueWikiIngest:
  * lib/services/source-processors/mineru-processor.ts
  * lib/services/source-processors/text-processor.ts
  * lib/services/source-processors/webpage-processor.ts
  * lib/actions/sources.ts (wechat handler)

Now every source path goes through the BullMQ queue, the ingest-worker actually processes the jobs (with retries, per-user fairness, per-notebook lock, status polling), and the upload HTTP request returns as soon as the source row hits READY.

`workers/ingest.ts` remains the sole runtime caller of `ingestSourceToWiki` — i.e. there's now exactly one place where the slow LLM extraction runs.