### PR TITLE
fix(queue): replace ':' separator in BullMQ job id (rejected by curre…

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -104,7 +104,7 @@ route `POST /api/notebooks/[id]/sources` calls `enqueueWikiIngest(...)`
 and returns immediately with a `jobId`; the worker drains the queue.
 
 - **Entry**: `workers/ingest.ts` — env vars `INGEST_WORKER_CONCURRENCY` (default 4) and `INGEST_PER_USER_CONCURRENCY` (default 2).
-- **Queue module**: `lib/queue/ingest-queue.ts` — job id is `nb:{notebookId}:src:{sourceId}`; pass `{ force: true }` to drop a stale completed/failed job before re-enqueueing (used by manual retry).
+- **Queue module**: `lib/queue/ingest-queue.ts` — job id is `nb-{notebookId}-src-{sourceId}` (recent BullMQ rejects custom ids containing `:`); pass `{ force: true }` to drop a stale completed/failed job before re-enqueueing (used by manual retry).
 - **Per-user fairness**: `lib/queue/user-slot.ts` uses a single Lua `EVAL` (`ZREMRANGEBYSCORE` + `ZCARD` + `ZADD`) so atomicity holds even when two workers race on the same user. Counter lives in Redis → scales across worker replicas.
 - **Per-notebook mutex**: `lib/queue/notebook-lock.ts` uses Redis `SET NX PX` with a 60 s heartbeat that extends TTL to 10 min — the lock survives long LLM runs without ever expiring mid-ingest.
 - **Reschedule protocol**: when contention is hit, the worker calls `job.moveToDelayed(...)` and throws BullMQ's `DelayedError` — the reschedule does NOT burn the `attempts: 3` budget.

--- a/apps/web/lib/queue/ingest-queue.ts
+++ b/apps/web/lib/queue/ingest-queue.ts
@@ -47,7 +47,9 @@ export function getWikiIngestQueue(): Queue<WikiIngestJobData, WikiIngestJobResu
  * existing job instead of stacking duplicates behind the worker.
  */
 function jobId(data: WikiIngestJobData): string {
-  return `nb:${data.notebookId}:src:${data.sourceId}`;
+  // Recent BullMQ rejects custom job ids that contain ":" because the
+  // library uses ":" as its key separator internally. Use "-" instead.
+  return `nb-${data.notebookId}-src-${data.sourceId}`;
 }
 
 export type EnqueueWikiIngestResult = {


### PR DESCRIPTION
…nt BullMQ)

The deterministic job id was `nb:{notebookId}:src:{sourceId}`. Recent BullMQ versions reject any custom id containing `:` because the library uses `:` internally as its key separator — every enqueue threw "Custom Id cannot contain :" and the wiki-ingest queue stayed empty (worker had nothing to drain).

Switch to `-` as the separator: `nb-{notebookId}-src-{sourceId}`. Functionally identical (still deterministic per notebook+source for de-dup / force-retry), just uses a separator BullMQ accepts.

CLAUDE.md updated to reflect the new format.