### PR TITLE
fix(settings): update DeepSeek model list; only show providers with a…

### DIFF
--- a/apps/web/components/settings/settings-workspace.tsx
+++ b/apps/web/components/settings/settings-workspace.tsx
@@ -224,7 +224,12 @@ export function SettingsWorkspace({ initialSettings, user }: SettingsWorkspacePr
         <main ref={mainScrollRef} className="flex-1 overflow-y-auto bg-sf-bg">
           <div className="mx-auto max-w-[1040px] px-10 py-10">
             {active === "models" && (
-              <AiModelsSection initialSettings={initialSettings} config={config} />
+              <AiModelsSection
+                initialSettings={initialSettings}
+                config={config}
+                apiKeyStatus={apiKeyStatus}
+                onOpenApiKeys={() => handleSelect("api-keys")}
+              />
             )}
             {active === "data-sources" && (
               <DataSourcesSection
@@ -374,9 +379,13 @@ function StatusBadge({
 function AiModelsSection({
   initialSettings,
   config,
+  apiKeyStatus,
+  onOpenApiKeys,
 }: {
   initialSettings?: InitialSettings;
   config: ModelsConfig | null;
+  apiKeyStatus: Record<string, ApiKeyStatus>;
+  onOpenApiKeys: () => void;
 }) {
   // Empty string = "not picked yet" (renders as a placeholder).
   // BYOK mandate: Save is disabled until all 8 slots are filled.
@@ -399,10 +408,15 @@ function AiModelsSection({
   const [isSaving, setIsSaving] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
 
+  // Only providers the user has actually configured a BYOK key for
+  // appear in the dropdowns. Surfacing every provider lets users pick
+  // one they can't actually use, then hit a runtime error mid-ingest.
   const providerOptions = useMemo(() => {
     if (!config) return [];
-    return Object.entries(config.providers).map(([id, { label }]) => ({ id, label }));
-  }, [config]);
+    return Object.entries(config.providers)
+      .filter(([id]) => apiKeyStatus[id]?.hasKey)
+      .map(([id, { label }]) => ({ id, label }));
+  }, [config, apiKeyStatus]);
 
   const getModels = useCallback(
     (providerId: string): ModelInfo[] => config?.providers[providerId]?.models || [],
@@ -514,6 +528,19 @@ function AiModelsSection({
       />
 
       <div className="flex flex-col gap-6 pb-24">
+        {config && providerOptions.length === 0 && (
+          <div className="rounded-[8px] border border-sf-line-strong bg-sf-bg-alt p-4 text-sm text-sf-ink-2">
+            No API keys configured yet. Add a BYOK key under{" "}
+            <button
+              type="button"
+              onClick={onOpenApiKeys}
+              className="font-semibold text-sf-accent underline decoration-sf-accent/40 underline-offset-2 hover:decoration-sf-accent"
+            >
+              API Keys
+            </button>{" "}
+            first; only providers with a saved key will appear in the dropdowns below.
+          </div>
+        )}
         <ModelsGroup title="Deepdive" description="Configure the models powering the Deepdive research and synthesis capabilities.">
           <ModelRow
             label="Chat Model"

--- a/apps/web/config/models.json
+++ b/apps/web/config/models.json
@@ -64,14 +64,14 @@
       "label": "DeepSeek",
       "models": [
         {
-          "id": "deepseek-chat",
-          "label": "DeepSeek Chat (V3.2)",
-          "desc": "Strong general-purpose, very low cost, 128K"
+          "id": "deepseek-v4-flash",
+          "label": "DeepSeek V4 Flash",
+          "desc": "Fast & low-cost general purpose, 128K"
         },
         {
-          "id": "deepseek-reasoner",
-          "label": "DeepSeek Reasoner (V3.2)",
-          "desc": "Thinking mode, deep reasoning, 128K"
+          "id": "deepseek-v4-pro",
+          "label": "DeepSeek V4 Pro",
+          "desc": "Stronger reasoning, deep thinking, 128K"
         }
       ]
     },
@@ -135,9 +135,9 @@
     "semopsModel": "gemini-2.5-flash"
   },
   "recommendations": {
-    "chat": "Fast models work best: Gemini 2.5 Flash, GPT-4.1 Mini, DeepSeek Chat. For complex research, try Gemini 3.1 Pro or GPT-5.4.",
-    "wiki": "Wiki extraction benefits from strong reasoning. Gemini 3.1 Pro, GPT-5.4, GLM-5.1, or DeepSeek Reasoner produce richer knowledge graphs. Flash models are fine for most content.",
-    "search": "The search agent finds sources for your notebook. A capable model with tool-use works best: Gemini 2.5 Flash, GPT-4.1, or DeepSeek Chat.",
-    "matcher": "Matcher compares queries against many items. Use a fast, affordable model: Gemini 2.5 Flash, DeepSeek Chat, or GPT-4.1 Nano."
+    "chat": "Fast models work best: Gemini 2.5 Flash, GPT-4.1 Mini, DeepSeek V4 Flash. For complex research, try Gemini 3.1 Pro or GPT-5.4.",
+    "wiki": "Wiki extraction benefits from strong reasoning. Gemini 3.1 Pro, GPT-5.4, GLM-5.1, or DeepSeek V4 Pro produce richer knowledge graphs. Flash models are fine for most content.",
+    "search": "The search agent finds sources for your notebook. A capable model with tool-use works best: Gemini 2.5 Flash, GPT-4.1, or DeepSeek V4 Flash.",
+    "matcher": "Matcher compares queries against many items. Use a fast, affordable model: Gemini 2.5 Flash, DeepSeek V4 Flash, or GPT-4.1 Nano."
   }
 }


### PR DESCRIPTION
… saved BYOK key

DeepSeek model rename
* deepseek-chat / deepseek-reasoner (V3.2 era) → deepseek-v4-flash / deepseek-v4-pro to match the actual model IDs DeepSeek's API currently exposes. Selecting the old IDs would 4xx mid-ingest.
* recommendations[] strings updated to reference the new labels.

Provider dropdowns: filter by configured API key
* AiModelsSection now receives apiKeyStatus from the parent and filters providerOptions to only those where hasKey === true. Users can no longer pick a provider they have no key for, then hit a runtime error during wiki ingest / chat.
* When the user has zero keys configured, render an inline banner pointing them at the API Keys section (via onOpenApiKeys callback so the click switches sections + URL hash, not just the URL).