### PR TITLE
feat(web): optimize tour guide — fresh-signup welcome, replay, prereq…

### DIFF
--- a/apps/web/app/api/guides/state/route.ts
+++ b/apps/web/app/api/guides/state/route.ts
@@ -11,7 +11,7 @@ export async function GET(): Promise<NextResponse<GuideState | { error: string }
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { tourCompletedAt: true, dismissedGuides: true },
+    select: { tourCompletedAt: true, welcomePending: true, dismissedGuides: true },
   });
 
   if (!user) {
@@ -20,14 +20,19 @@ export async function GET(): Promise<NextResponse<GuideState | { error: string }
 
   return NextResponse.json({
     tourCompletedAt: user.tourCompletedAt ? user.tourCompletedAt.toISOString() : null,
+    welcomePending: user.welcomePending,
     dismissedGuides: user.dismissedGuides,
   });
 }
 
 interface PatchBody {
+  /** Skip / Finish — flips welcomePending off too so the modal won't return. */
   markTourCompleted?: boolean;
+  /** Start — flips welcomePending off without marking the tour as completed. */
+  dismissWelcome?: boolean;
   dismissGuideId?: string;
   undismissGuideId?: string;
+  /** Replay — re-arms the welcome modal and clears tourCompletedAt. */
   resetTour?: boolean;
 }
 
@@ -41,7 +46,7 @@ export async function PATCH(request: Request): Promise<NextResponse<GuideState |
 
   const current = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { id: true, tourCompletedAt: true, dismissedGuides: true },
+    select: { id: true, tourCompletedAt: true, welcomePending: true, dismissedGuides: true },
   });
   if (!current) {
     return NextResponse.json({ error: "user_not_found" }, { status: 404 });
@@ -51,21 +56,31 @@ export async function PATCH(request: Request): Promise<NextResponse<GuideState |
   if (body.dismissGuideId) nextDismissed.add(body.dismissGuideId);
   if (body.undismissGuideId) nextDismissed.delete(body.undismissGuideId);
 
+  let nextTourCompleted = current.tourCompletedAt;
+  let nextWelcomePending = current.welcomePending;
+  if (body.resetTour) {
+    nextTourCompleted = null;
+    nextWelcomePending = true;
+  } else if (body.markTourCompleted) {
+    nextTourCompleted = new Date();
+    nextWelcomePending = false;
+  } else if (body.dismissWelcome) {
+    nextWelcomePending = false;
+  }
+
   const updated = await prisma.user.update({
     where: { id: current.id },
     data: {
-      tourCompletedAt: body.resetTour
-        ? null
-        : body.markTourCompleted
-          ? new Date()
-          : current.tourCompletedAt,
+      tourCompletedAt: nextTourCompleted,
+      welcomePending: nextWelcomePending,
       dismissedGuides: Array.from(nextDismissed),
     },
-    select: { tourCompletedAt: true, dismissedGuides: true },
+    select: { tourCompletedAt: true, welcomePending: true, dismissedGuides: true },
   });
 
   return NextResponse.json({
     tourCompletedAt: updated.tourCompletedAt ? updated.tourCompletedAt.toISOString() : null,
+    welcomePending: updated.welcomePending,
     dismissedGuides: updated.dismissedGuides,
   });
 }

--- a/apps/web/app/api/signup/route.ts
+++ b/apps/web/app/api/signup/route.ts
@@ -40,6 +40,8 @@ export async function POST(req: Request) {
         username,
         email,
         passwordHash,
+        // Auto-prompt the first-run tour on the next session — and only that one.
+        welcomePending: true,
       },
     });
 

--- a/apps/web/components/guides/guide-drawer.tsx
+++ b/apps/web/components/guides/guide-drawer.tsx
@@ -5,7 +5,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { AnimatePresence, motion } from "framer-motion";
 import * as LucideIcons from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { X, Play, BookOpen, EyeOff, Search as SearchIcon } from "lucide-react";
+import { X, Play, BookOpen, EyeOff, Search as SearchIcon, Info } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { GUIDES } from "@/content/guides";
 import type { GuideCategory, GuideDefinition } from "@/content/guides/types";
@@ -135,6 +135,26 @@ export function GuideDrawer() {
                               </button>
                               {expandedId === g.id ? (
                                 <>
+                                  {g.prereq ? (
+                                    <div className="flex items-start gap-2 border-t border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
+                                      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                                      <span className="flex-1">
+                                        {t(g.prereq.hintKey.replace(/^guides\./, ""))}
+                                      </span>
+                                      <button
+                                        type="button"
+                                        onClick={() => {
+                                          const setupId = g.prereq?.setupGuideId;
+                                          if (!setupId) return;
+                                          setDrawerOpen(false);
+                                          openGuide(setupId);
+                                        }}
+                                        className="shrink-0 rounded border border-amber-600/40 px-2 py-0.5 text-[11px] font-medium hover:bg-amber-500/15"
+                                      >
+                                        {t("action.setupFirst")}
+                                      </button>
+                                    </div>
+                                  ) : null}
                                   <div className="flex gap-2 border-t border-border bg-muted/10 px-2 py-2">
                                     <button
                                       type="button"

--- a/apps/web/components/guides/guide-layer.tsx
+++ b/apps/web/components/guides/guide-layer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import type { GuideStepPlacement } from "@/content/guides/types";
 import { GuideBubble } from "./guide-bubble";
+import { REDUCED, SPRING, tooltipPosition } from "./lib";
+import { useGuideOverlay } from "./use-guide-overlay";
 
 interface GuideLayerProps {
   /** Optional — intro / outro steps without a target render a centered bubble. */
@@ -21,63 +22,6 @@ interface GuideLayerProps {
   prevLabel: string;
   closeLabel: string;
   finishLabel: string;
-}
-
-interface Rect {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}
-
-const RING_PADDING = 6;
-const SPRING = { type: "spring" as const, damping: 30, stiffness: 280 };
-
-function getRect(selector: string): Rect | null {
-  if (typeof document === "undefined") return null;
-  const el = document.querySelector(selector);
-  if (!el) return null;
-  const r = el.getBoundingClientRect();
-  if (r.width === 0 && r.height === 0) return null;
-  return {
-    top: r.top + window.scrollY - RING_PADDING,
-    left: r.left + window.scrollX - RING_PADDING,
-    width: r.width + RING_PADDING * 2,
-    height: r.height + RING_PADDING * 2,
-  };
-}
-
-function tooltipPosition(rect: Rect, placement: GuideStepPlacement) {
-  switch (placement) {
-    case "top":
-      return {
-        top: rect.top - 12,
-        left: rect.left + rect.width / 2,
-        x: "-50%",
-        y: "-100%",
-      };
-    case "bottom":
-      return {
-        top: rect.top + rect.height + 12,
-        left: rect.left + rect.width / 2,
-        x: "-50%",
-        y: 0,
-      };
-    case "left":
-      return {
-        top: rect.top + rect.height / 2,
-        left: rect.left - 12,
-        x: "-100%",
-        y: "-50%",
-      };
-    case "right":
-      return {
-        top: rect.top + rect.height / 2,
-        left: rect.left + rect.width + 12,
-        x: 0,
-        y: "-50%",
-      };
-  }
 }
 
 /**
@@ -100,92 +44,16 @@ export function GuideLayer({
   closeLabel,
   finishLabel,
 }: GuideLayerProps) {
-  const [rect, setRect] = useState<Rect | null>(null);
-  const [lastSelector, setLastSelector] = useState<string | undefined>(selector);
-  const [isMobile, setIsMobile] = useState(false);
-
-  // Reset rect when the selector changes (setState-during-render pattern — the
-  // React 19 idiom to derive state from a prop without a useEffect).
-  if (selector !== lastSelector) {
-    setLastSelector(selector);
-    setRect(null);
-  }
-
-  const mounted = useSyncExternalStore(
-    () => () => {},
-    () => true,
-    () => false,
-  );
-
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 640px)");
-    const handler = () => setIsMobile(mq.matches);
-    handler();
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!selector) return;
-    let raf = 0;
-    let prev: Rect | null = null;
-    function update() {
-      if (!selector) return;
-      const next = getRect(selector);
-      const changed =
-        (prev === null) !== (next === null) ||
-        (prev !== null &&
-          next !== null &&
-          (prev.top !== next.top ||
-            prev.left !== next.left ||
-            prev.width !== next.width ||
-            prev.height !== next.height));
-      if (changed) {
-        prev = next;
-        setRect(next);
-      }
-      raf = window.requestAnimationFrame(update);
-    }
-    const timeout = window.setTimeout(() => {
-      window.cancelAnimationFrame(raf);
-    }, 1500);
-    update();
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
-    return () => {
-      window.cancelAnimationFrame(raf);
-      window.clearTimeout(timeout);
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
-    };
-  }, [selector]);
-
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-      const target = e.target as HTMLElement | null;
-      // Skip events that originated inside the guide overlay — the bubble's
-      // Next / Back buttons handle Enter natively, so letting the window
-      // listener ALSO fire would advance twice.
-      if (target?.closest("[data-guide-portal]")) return;
-      const tag = target?.tagName;
-      const isEditable =
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        tag === "SELECT" ||
-        target?.isContentEditable === true;
-      if (isEditable) return;
-      if (e.key === "ArrowRight" || e.key === "Enter") onNext();
-      else if (e.key === "ArrowLeft" && onPrev) onPrev();
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onNext, onPrev, onClose]);
+  const { mounted, isMobile, reducedMotion, rect } = useGuideOverlay({
+    selector,
+    onNext,
+    onPrev,
+    onClose,
+  });
 
   if (!mounted) return null;
+
+  const transition = reducedMotion ? REDUCED : SPRING;
 
   const bubble = (
     <GuideBubble
@@ -256,7 +124,7 @@ export function GuideLayer({
           width: rect.width,
           height: rect.height,
         }}
-        transition={SPRING}
+        transition={transition}
         className="pointer-events-none fixed z-50 rounded-md ring-2 ring-indigo-500 shadow-[0_0_0_4px_rgba(99,102,241,0.15)]"
       />
       {/* Bubble — also animated */}
@@ -270,7 +138,7 @@ export function GuideLayer({
           x: pos.x,
           y: pos.y,
         }}
-        transition={SPRING}
+        transition={transition}
         className="pointer-events-auto fixed z-50"
       >
         {bubble}

--- a/apps/web/components/guides/guide-provider.tsx
+++ b/apps/web/components/guides/guide-provider.tsx
@@ -11,7 +11,7 @@ import {
   type ReactNode,
 } from "react";
 import type { GuideState } from "@/content/guides/types";
-import { GUIDE_STATE_STORAGE_KEY } from "@/content/guides/types";
+import { GUIDE_STATE_STORAGE_KEY, TOUR_PROGRESS_STORAGE_KEY } from "@/content/guides/types";
 
 type GuideActionHandler = () => void | Promise<void>;
 
@@ -25,13 +25,21 @@ interface GuideContextValue extends GuideState {
   closeGuide: () => void;
   dismissGuide: (id: string) => Promise<void>;
   undismissGuide: (id: string) => Promise<void>;
+  /** Flip welcomePending off without marking the tour completed (Start). */
+  dismissWelcome: () => Promise<void>;
+  /** Skip / Finish — flips welcomePending off and stamps tourCompletedAt. */
   markTourCompleted: () => Promise<void>;
+  /** Replay — re-arms the welcome modal, wipes any local progress marker. */
   resetTour: () => Promise<void>;
   registerGuideAction: (name: string, handler: GuideActionHandler) => () => void;
   runGuideAction: (name: string, options?: { timeoutMs?: number }) => Promise<boolean>;
 }
 
-const EMPTY_STATE: GuideState = { tourCompletedAt: null, dismissedGuides: [] };
+const EMPTY_STATE: GuideState = {
+  tourCompletedAt: null,
+  welcomePending: false,
+  dismissedGuides: [],
+};
 
 const GuideContext = createContext<GuideContextValue | null>(null);
 
@@ -43,6 +51,7 @@ function readLocalState(): GuideState {
     const parsed = JSON.parse(raw) as Partial<GuideState>;
     return {
       tourCompletedAt: parsed.tourCompletedAt ?? null,
+      welcomePending: Boolean(parsed.welcomePending),
       dismissedGuides: Array.isArray(parsed.dismissedGuides) ? parsed.dismissedGuides : [],
     };
   } catch {
@@ -54,6 +63,15 @@ function writeLocalState(state: GuideState) {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(GUIDE_STATE_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* ignore */
+  }
+}
+
+function clearLocalProgress() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(TOUR_PROGRESS_STORAGE_KEY);
   } catch {
     /* ignore */
   }
@@ -106,11 +124,19 @@ export function GuideProvider({
 
   const patch = useCallback(
     async (body: Record<string, unknown>) => {
+      if (body.resetTour) clearLocalProgress();
       if (!isAuthenticated) {
         setState((prev) => {
           const next: GuideState = { ...prev };
-          if (body.markTourCompleted) next.tourCompletedAt = new Date().toISOString();
-          if (body.resetTour) next.tourCompletedAt = null;
+          if (body.markTourCompleted) {
+            next.tourCompletedAt = new Date().toISOString();
+            next.welcomePending = false;
+          }
+          if (body.dismissWelcome) next.welcomePending = false;
+          if (body.resetTour) {
+            next.tourCompletedAt = null;
+            next.welcomePending = true;
+          }
           if (typeof body.dismissGuideId === "string") {
             next.dismissedGuides = Array.from(new Set([...prev.dismissedGuides, body.dismissGuideId]));
           }
@@ -187,6 +213,7 @@ export function GuideProvider({
       closeGuide: () => setActiveGuideId(null),
       dismissGuide: (id) => patch({ dismissGuideId: id }),
       undismissGuide: (id) => patch({ undismissGuideId: id }),
+      dismissWelcome: () => patch({ dismissWelcome: true }),
       markTourCompleted: () => patch({ markTourCompleted: true }),
       resetTour: () => patch({ resetTour: true }),
       registerGuideAction,

--- a/apps/web/components/guides/lib.ts
+++ b/apps/web/components/guides/lib.ts
@@ -1,0 +1,86 @@
+import type { Transition } from "framer-motion";
+import type { GuideStepPlacement } from "@/content/guides/types";
+
+export interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export const RING_PADDING = 6;
+
+// Bubble dimensions (kept in sync with GuideBubble): w-80 = 320px wide. Height
+// is dynamic; ~200px is a safe upper bound used for vertical viewport clamping.
+export const BUBBLE_WIDTH = 320;
+export const BUBBLE_MAX_HEIGHT = 200;
+export const VIEWPORT_MARGIN = 12;
+
+export const SPRING: Transition = { type: "spring", damping: 30, stiffness: 280 };
+// Used when the OS reports prefers-reduced-motion — drop the spring overshoot.
+export const REDUCED: Transition = { type: "tween", duration: 0.15, ease: "easeOut" };
+
+export function getRect(selector: string): Rect | null {
+  if (typeof document === "undefined") return null;
+  const el = document.querySelector(selector);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  if (r.width === 0 && r.height === 0) return null;
+  return {
+    top: r.top + window.scrollY - RING_PADDING,
+    left: r.left + window.scrollX - RING_PADDING,
+    width: r.width + RING_PADDING * 2,
+    height: r.height + RING_PADDING * 2,
+  };
+}
+
+export function clamp(v: number, min: number, max: number) {
+  return Math.min(Math.max(v, min), max);
+}
+
+export interface TooltipPos {
+  top: number;
+  left: number;
+  x: string | number;
+  y: string | number;
+}
+
+export function tooltipPosition(rect: Rect, placement: GuideStepPlacement): TooltipPos {
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 800;
+  const bubbleW = Math.min(BUBBLE_WIDTH, vw * 0.9);
+  const minCx = bubbleW / 2 + VIEWPORT_MARGIN;
+  const maxCx = vw - bubbleW / 2 - VIEWPORT_MARGIN;
+  const minCy = BUBBLE_MAX_HEIGHT / 2 + VIEWPORT_MARGIN;
+  const maxCy = vh - BUBBLE_MAX_HEIGHT / 2 - VIEWPORT_MARGIN;
+  switch (placement) {
+    case "top":
+      return {
+        top: rect.top - 12,
+        left: clamp(rect.left + rect.width / 2, minCx, maxCx),
+        x: "-50%",
+        y: "-100%",
+      };
+    case "bottom":
+      return {
+        top: rect.top + rect.height + 12,
+        left: clamp(rect.left + rect.width / 2, minCx, maxCx),
+        x: "-50%",
+        y: 0,
+      };
+    case "left":
+      return {
+        top: clamp(rect.top + rect.height / 2, minCy, maxCy),
+        left: rect.left - 12,
+        x: "-100%",
+        y: "-50%",
+      };
+    case "right":
+      return {
+        top: clamp(rect.top + rect.height / 2, minCy, maxCy),
+        left: rect.left + rect.width + 12,
+        x: 0,
+        y: "-50%",
+      };
+  }
+}

--- a/apps/web/components/guides/spotlight.tsx
+++ b/apps/web/components/guides/spotlight.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import type { GuideStepPlacement } from "@/content/guides/types";
 import { GuideBubble } from "./guide-bubble";
+import { REDUCED, SPRING, tooltipPosition } from "./lib";
+import { useGuideOverlay } from "./use-guide-overlay";
 
 interface SpotlightProps {
   /** Optional — intro / outro steps without a target render a centered bubble. */
@@ -21,43 +22,6 @@ interface SpotlightProps {
   prevLabel: string;
   closeLabel: string;
   finishLabel: string;
-}
-
-interface Rect {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}
-
-const RING_PADDING = 6;
-const SPRING = { type: "spring" as const, damping: 30, stiffness: 280 };
-
-function getRect(selector: string): Rect | null {
-  if (typeof document === "undefined") return null;
-  const el = document.querySelector(selector);
-  if (!el) return null;
-  const r = el.getBoundingClientRect();
-  if (r.width === 0 && r.height === 0) return null;
-  return {
-    top: r.top + window.scrollY - RING_PADDING,
-    left: r.left + window.scrollX - RING_PADDING,
-    width: r.width + RING_PADDING * 2,
-    height: r.height + RING_PADDING * 2,
-  };
-}
-
-function tooltipPosition(rect: Rect, placement: GuideStepPlacement) {
-  switch (placement) {
-    case "top":
-      return { top: rect.top - 12, left: rect.left + rect.width / 2, x: "-50%", y: "-100%" };
-    case "bottom":
-      return { top: rect.top + rect.height + 12, left: rect.left + rect.width / 2, x: "-50%", y: 0 };
-    case "left":
-      return { top: rect.top + rect.height / 2, left: rect.left - 12, x: "-100%", y: "-50%" };
-    case "right":
-      return { top: rect.top + rect.height / 2, left: rect.left + rect.width + 12, x: 0, y: "-50%" };
-  }
 }
 
 /**
@@ -80,89 +44,16 @@ export function Spotlight({
   closeLabel,
   finishLabel,
 }: SpotlightProps) {
-  const [rect, setRect] = useState<Rect | null>(null);
-  const [lastSelector, setLastSelector] = useState<string | undefined>(selector);
-  const [isMobile, setIsMobile] = useState(false);
-
-  // Reset rect when the selector changes (setState-during-render pattern — the
-  // React 19 idiom to derive state from a prop without a useEffect).
-  if (selector !== lastSelector) {
-    setLastSelector(selector);
-    setRect(null);
-  }
-
-  const mounted = useSyncExternalStore(
-    () => () => {},
-    () => true,
-    () => false,
-  );
-
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 640px)");
-    const handler = () => setIsMobile(mq.matches);
-    handler();
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!selector) return;
-    let raf = 0;
-    let prev: Rect | null = null;
-    function update() {
-      if (!selector) return;
-      const next = getRect(selector);
-      const changed =
-        (prev === null) !== (next === null) ||
-        (prev !== null &&
-          next !== null &&
-          (prev.top !== next.top ||
-            prev.left !== next.left ||
-            prev.width !== next.width ||
-            prev.height !== next.height));
-      if (changed) {
-        prev = next;
-        setRect(next);
-      }
-      raf = window.requestAnimationFrame(update);
-    }
-    const timeout = window.setTimeout(() => {
-      window.cancelAnimationFrame(raf);
-    }, 1500);
-    update();
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
-    return () => {
-      window.cancelAnimationFrame(raf);
-      window.clearTimeout(timeout);
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
-    };
-  }, [selector]);
-
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-      const target = e.target as HTMLElement | null;
-      if (target?.closest("[data-guide-portal]")) return;
-      const tag = target?.tagName;
-      const isEditable =
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        tag === "SELECT" ||
-        target?.isContentEditable === true;
-      if (isEditable) return;
-      if (e.key === "ArrowRight" || e.key === "Enter") onNext();
-      else if (e.key === "ArrowLeft" && onPrev) onPrev();
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onNext, onPrev, onClose]);
+  const { mounted, isMobile, reducedMotion, rect } = useGuideOverlay({
+    selector,
+    onNext,
+    onPrev,
+    onClose,
+  });
 
   if (!mounted) return null;
+
+  const transition = reducedMotion ? REDUCED : SPRING;
 
   const bubble = (
     <GuideBubble
@@ -226,28 +117,28 @@ export function Spotlight({
         data-guide-portal
         className="pointer-events-auto fixed bg-black/55"
         animate={{ top: 0, left: 0, right: 0, height: rect.top }}
-        transition={SPRING}
+        transition={transition}
         onClick={onClose}
       />
       <motion.div
         data-guide-portal
         className="pointer-events-auto fixed bg-black/55"
         animate={{ top: rect.top + rect.height, left: 0, right: 0, bottom: 0 }}
-        transition={SPRING}
+        transition={transition}
         onClick={onClose}
       />
       <motion.div
         data-guide-portal
         className="pointer-events-auto fixed bg-black/55"
         animate={{ top: rect.top, left: 0, width: rect.left, height: rect.height }}
-        transition={SPRING}
+        transition={transition}
         onClick={onClose}
       />
       <motion.div
         data-guide-portal
         className="pointer-events-auto fixed bg-black/55"
         animate={{ top: rect.top, left: rect.left + rect.width, right: 0, height: rect.height }}
-        transition={SPRING}
+        transition={transition}
         onClick={onClose}
       />
       {/* Ring around the hole. */}
@@ -255,14 +146,14 @@ export function Spotlight({
         data-guide-portal
         className="pointer-events-none fixed rounded-md ring-2 ring-indigo-500"
         animate={{ top: rect.top, left: rect.left, width: rect.width, height: rect.height }}
-        transition={SPRING}
+        transition={transition}
       />
       {/* Bubble. */}
       <motion.div
         data-guide-portal
         className="pointer-events-auto fixed"
         animate={{ top: pos.top, left: pos.left, x: pos.x, y: pos.y }}
-        transition={SPRING}
+        transition={transition}
       >
         {bubble}
       </motion.div>

--- a/apps/web/components/guides/use-first-run-tour.ts
+++ b/apps/web/components/guides/use-first-run-tour.ts
@@ -7,7 +7,8 @@ import { TOUR_PROGRESS_STORAGE_KEY } from "@/content/guides/types";
 import { useGuides } from "./guide-provider";
 
 export function useFirstRunTour() {
-  const { loading, tourCompletedAt, markTourCompleted } = useGuides();
+  const { loading, welcomePending, tourCompletedAt, dismissWelcome, markTourCompleted } = useGuides();
+
   // Read resumed progress once on mount (client-only).
   const [stepIndex, setStepIndex] = useState<number>(() => {
     if (typeof window === "undefined") return 0;
@@ -24,7 +25,7 @@ export function useFirstRunTour() {
   });
 
   // Whether there was a resumable progress marker at mount time.
-  const [hadResume] = useState<boolean>(() => {
+  const [hadResume, setHadResume] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     try {
       return window.localStorage.getItem(TOUR_PROGRESS_STORAGE_KEY) !== null;
@@ -36,24 +37,41 @@ export function useFirstRunTour() {
   // Manual stage transitions (user clicks Start / Skip / Finish).
   const [manualStage, setManualStage] = useState<"running" | "done" | null>(null);
 
+  // When the drawer's "Replay tour" button fires, the server flips
+  // welcomePending back on. Drop stale manualStage / hadResume so the welcome
+  // modal can re-appear in the same session — setState-during-render keeps
+  // this side-effect free without bouncing through useEffect.
+  const [lastWelcomePending, setLastWelcomePending] = useState(welcomePending);
+  if (welcomePending !== lastWelcomePending) {
+    setLastWelcomePending(welcomePending);
+    if (welcomePending && !loading) {
+      setManualStage(null);
+      setHadResume(false);
+      setStepIndex(0);
+    }
+  }
+
   const router = useRouter();
   const pathname = usePathname();
 
-  // Derive stage without an effect. Order of precedence:
-  //   1. Manual transitions win (user clicked a button).
-  //   2. Still loading initial state → idle.
-  //   3. tourCompletedAt present → done.
-  //   4. Had resumable progress in localStorage → running.
-  //   5. Otherwise show the welcome modal.
-  const stage: "idle" | "welcome" | "running" | "done" = manualStage
-    ? manualStage
-    : loading
-      ? "idle"
-      : tourCompletedAt
-        ? "done"
-        : hadResume
-          ? "running"
-          : "welcome";
+  // Stage decision (in priority order):
+  //   1. While loading initial state → idle (don't flash a welcome).
+  //   2. welcomePending true → welcome (unless user already clicked Start).
+  //   3. Manual transition is the source of truth in-session.
+  //   4. Resumable progress → running.
+  //   5. Otherwise dormant.
+  let stage: "idle" | "welcome" | "running" | "done";
+  if (loading) {
+    stage = "idle";
+  } else if (welcomePending) {
+    stage = manualStage === "running" ? "running" : "welcome";
+  } else if (manualStage) {
+    stage = manualStage;
+  } else if (hadResume) {
+    stage = "running";
+  } else {
+    stage = "done";
+  }
 
   function saveProgress(next: number) {
     if (typeof window === "undefined") return;
@@ -73,14 +91,18 @@ export function useFirstRunTour() {
   return {
     stage,
     stepIndex,
-    start: () => {
+    tourCompletedAt,
+    start: async () => {
       setManualStage("running");
       saveProgress(0);
+      // Flip welcomePending off so a reload mid-tour resumes via hadResume,
+      // not by re-showing the welcome modal.
+      await dismissWelcome();
     },
     skip: async () => {
       clearProgress();
-      await markTourCompleted();
       setManualStage("done");
+      await markTourCompleted();
     },
     next: () => {
       const n = stepIndex + 1;
@@ -94,8 +116,8 @@ export function useFirstRunTour() {
     },
     finish: async () => {
       clearProgress();
-      await markTourCompleted();
       setManualStage("done");
+      await markTourCompleted();
     },
     navigate: (route: string) => router.push(route),
   };

--- a/apps/web/components/guides/use-guide-overlay.ts
+++ b/apps/web/components/guides/use-guide-overlay.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useState, useSyncExternalStore } from "react";
+import { getRect, type Rect } from "./lib";
+
+interface OverlayOptions {
+  selector: string | undefined;
+  onNext: () => void;
+  onPrev?: () => void;
+  onClose: () => void;
+}
+
+interface OverlayState {
+  /** False during SSR / first render → portal is gated until hydration. */
+  mounted: boolean;
+  /** True under the 640px breakpoint — both overlays switch to a bottom sheet. */
+  isMobile: boolean;
+  /** True when the OS reports prefers-reduced-motion: reduce. */
+  reducedMotion: boolean;
+  /** Document-relative rect of the highlighted element, or null when missing. */
+  rect: Rect | null;
+}
+
+/**
+ * Shared lifecycle for tour overlays. Tracks the target element's rect, mobile
+ * breakpoint, and reduced-motion preference; wires Escape / Arrow / Enter so
+ * both Spotlight (first-run) and GuideLayer (drawer Play) stay in sync.
+ *
+ * Position tracking uses a ResizeObserver on the target plus window scroll /
+ * resize listeners — far cheaper than the previous 60fps rAF burst and, more
+ * importantly, keeps tracking forever (no 1500 ms cap), so panel resizes mid
+ * tour update the highlight correctly.
+ */
+export function useGuideOverlay({ selector, onNext, onPrev, onClose }: OverlayOptions): OverlayState {
+  const [rect, setRect] = useState<Rect | null>(null);
+  const [lastSelector, setLastSelector] = useState<string | undefined>(selector);
+  const [isMobile, setIsMobile] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  // Reset rect when the selector changes (setState-during-render — the React 19
+  // idiom to derive state from a prop without a useEffect).
+  if (selector !== lastSelector) {
+    setLastSelector(selector);
+    setRect(null);
+  }
+
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 640px)");
+    const handler = () => setIsMobile(mq.matches);
+    handler();
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = () => setReducedMotion(mq.matches);
+    handler();
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!selector) return;
+    let cancelled = false;
+    let prev: Rect | null = null;
+    let observed: Element | null = null;
+    let resizeObs: ResizeObserver | null = null;
+    let mutationObs: MutationObserver | null = null;
+
+    function update() {
+      if (cancelled || !selector) return;
+      const next = getRect(selector);
+      const changed =
+        (prev === null) !== (next === null) ||
+        (prev !== null &&
+          next !== null &&
+          (prev.top !== next.top ||
+            prev.left !== next.left ||
+            prev.width !== next.width ||
+            prev.height !== next.height));
+      if (changed) {
+        prev = next;
+        setRect(next);
+      }
+      // Re-attach the ResizeObserver if the selector now resolves to a
+      // different element (e.g. the dialog the trigger opens).
+      const el = selector ? document.querySelector(selector) : null;
+      if (el !== observed) {
+        if (resizeObs && observed) resizeObs.unobserve(observed);
+        observed = el;
+        if (resizeObs && el) resizeObs.observe(el);
+      }
+    }
+
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObs = new ResizeObserver(update);
+    }
+
+    // DOM mutations can swap the matched element (e.g. before/after a
+    // dialog mounts) — re-run update so we re-bind the observer.
+    if (typeof MutationObserver !== "undefined") {
+      mutationObs = new MutationObserver(update);
+      mutationObs.observe(document.body, { childList: true, subtree: true });
+    }
+
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+
+    // Settle initial layout — Framer step-in animations may shift the target a
+    // few frames after mount. A short rAF burst captures those without paying
+    // the 60fps cost forever.
+    let raf = 0;
+    const start = performance.now();
+    function settle() {
+      update();
+      if (cancelled) return;
+      if (performance.now() - start < 400) {
+        raf = window.requestAnimationFrame(settle);
+      }
+    }
+    raf = window.requestAnimationFrame(settle);
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+      resizeObs?.disconnect();
+      mutationObs?.disconnect();
+    };
+  }, [selector]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      const target = e.target as HTMLElement | null;
+      // Skip events that originated inside the guide overlay — the bubble's
+      // own buttons handle Enter natively, so letting this listener also fire
+      // would advance twice.
+      if (target?.closest("[data-guide-portal]")) return;
+      const tag = target?.tagName;
+      const isEditable =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target?.isContentEditable === true;
+      if (isEditable) return;
+      if (e.key === "ArrowRight" || e.key === "Enter") onNext();
+      else if (e.key === "ArrowLeft" && onPrev) onPrev();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onNext, onPrev, onClose]);
+
+  return { mounted, isMobile, reducedMotion, rect };
+}

--- a/apps/web/content/guides/add-sources.ts
+++ b/apps/web/content/guides/add-sources.ts
@@ -7,8 +7,9 @@ export const addSourcesGuide: GuideDefinition = {
   titleKey: "guides.addSources.title",
   summaryKey: "guides.addSources.summary",
   publicOnLanding: true,
-  includeInFirstRunTour: true,
-  firstRunTourOrder: 2,
+  // Removed from the first-run tour — needs an existing notebook, which a
+  // brand-new user does not have. The drawer's prereq hint covers that case.
+  prereq: { hintKey: "guides.addSources.prereq", setupGuideId: "create-notebook" },
   // When the guide fully closes (Finish or user-close), return the page to
   // the exact state it was in before the demo started: close the dialog AND
   // wipe any transient state the guide changed along the way (view toggles,

--- a/apps/web/content/guides/byok-api-keys.ts
+++ b/apps/web/content/guides/byok-api-keys.ts
@@ -7,7 +7,7 @@ export const byokApiKeysGuide: GuideDefinition = {
   titleKey: "guides.byokApiKeys.title",
   summaryKey: "guides.byokApiKeys.summary",
   includeInFirstRunTour: true,
-  firstRunTourOrder: 3,
+  firstRunTourOrder: 2,
   steps: [
     // 1 — Navigate to Settings and show where API Keys lives in the sidebar.
     {

--- a/apps/web/content/guides/chat-with-ai.ts
+++ b/apps/web/content/guides/chat-with-ai.ts
@@ -7,8 +7,8 @@ export const chatWithAiGuide: GuideDefinition = {
   titleKey: "guides.chatWithAi.title",
   summaryKey: "guides.chatWithAi.summary",
   publicOnLanding: true,
-  includeInFirstRunTour: true,
-  firstRunTourOrder: 4,
+  // Removed from the first-run tour — needs an existing notebook.
+  prereq: { hintKey: "guides.chatWithAi.prereq", setupGuideId: "create-notebook" },
   steps: [
     // 1 — Point at the chat input. Takes the user to a notebook workspace first.
     {

--- a/apps/web/content/guides/conferences.ts
+++ b/apps/web/content/guides/conferences.ts
@@ -6,6 +6,8 @@ export const conferencesGuide: GuideDefinition = {
   icon: "CalendarDays",
   titleKey: "guides.conferences.title",
   summaryKey: "guides.conferences.summary",
+  includeInFirstRunTour: true,
+  firstRunTourOrder: 3,
   steps: [
     // 1 — Filter by venue.
     {

--- a/apps/web/content/guides/matcher.ts
+++ b/apps/web/content/guides/matcher.ts
@@ -6,6 +6,8 @@ export const matcherGuide: GuideDefinition = {
   icon: "Target",
   titleKey: "guides.matcher.title",
   summaryKey: "guides.matcher.summary",
+  includeInFirstRunTour: true,
+  firstRunTourOrder: 4,
   steps: [
     // 1 — Point at the upload dropzone / query preview.
     {

--- a/apps/web/content/guides/notes.ts
+++ b/apps/web/content/guides/notes.ts
@@ -6,6 +6,7 @@ export const notesGuide: GuideDefinition = {
   icon: "NotebookPen",
   titleKey: "guides.notes.title",
   summaryKey: "guides.notes.summary",
+  prereq: { hintKey: "guides.notes.prereq", setupGuideId: "create-notebook" },
   onExit: { kind: "action", name: "close-create-note" },
   steps: [
     // 1 — Arrive at the Notes tab. close-create-note ensures the dialog is shut

--- a/apps/web/content/guides/types.ts
+++ b/apps/web/content/guides/types.ts
@@ -45,6 +45,19 @@ export interface GuideStep {
   advanceOn?: GuideAdvanceMode;
 }
 
+/**
+ * Declarative precondition for a single guide. Rendered in the drawer as a
+ * hint banner above Play; the "Set up first" button launches `setupGuideId`
+ * to walk the user through the missing setup. No runtime check today — the
+ * field is informational only, but the type leaves room for one later.
+ */
+export interface GuidePrereq {
+  /** next-intl key for the hint copy ("You need a notebook first."). */
+  hintKey: string;
+  /** Guide id to launch when the user clicks "Set up first". */
+  setupGuideId: string;
+}
+
 export interface GuideDefinition {
   /** Stable, forever-unchanging ID. Used in dismissedGuides[]. */
   id: string;
@@ -59,6 +72,8 @@ export interface GuideDefinition {
   includeInFirstRunTour?: boolean;
   /** 1-indexed order within the first-run tour. Required if includeInFirstRunTour. */
   firstRunTourOrder?: number;
+  /** Optional declarative precondition shown in the drawer. */
+  prereq?: GuidePrereq;
   steps: GuideStep[];
   /**
    * Fired once when the guide fully closes (Finish, Skip, or user-close).
@@ -70,6 +85,12 @@ export interface GuideDefinition {
 
 export interface GuideState {
   tourCompletedAt: string | null;
+  /**
+   * True iff the welcome modal should auto-prompt on next mount. Set on
+   * signup; cleared when the user clicks Start or Skip; re-armed by the
+   * drawer's "Replay tour" button.
+   */
+  welcomePending: boolean;
   dismissedGuides: string[];
 }
 

--- a/apps/web/content/guides/wiki-graph.ts
+++ b/apps/web/content/guides/wiki-graph.ts
@@ -6,6 +6,7 @@ export const wikiGraphGuide: GuideDefinition = {
   icon: "Network",
   titleKey: "guides.wikiGraph.title",
   summaryKey: "guides.wikiGraph.summary",
+  prereq: { hintKey: "guides.wikiGraph.prereq", setupGuideId: "create-notebook" },
   steps: [
     // 1 — Make sure we're in a notebook on the Wiki tab, then highlight the tab.
     {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -431,7 +431,8 @@
     "action": {
       "play": "Play",
       "read": "Read",
-      "dismiss": "Don't show again"
+      "dismiss": "Don't show again",
+      "setupFirst": "Set up first"
     },
     "tour": {
       "welcomeTitle": "Welcome to SparkFlow",
@@ -467,6 +468,7 @@
     "addSources": {
       "title": "Add sources",
       "summary": "Upload files, folders, or URLs — up to 50 at once.",
+      "prereq": "Needs an existing notebook. Create one first.",
       "step1": {
         "title": "Let's add some sources",
         "body": "We'll jump into your most recent notebook and walk through the Add Source dialog."
@@ -503,6 +505,7 @@
     "chatWithAi": {
       "title": "Chat with AI",
       "summary": "Questions grounded in your sources — answers cite the original.",
+      "prereq": "Needs a notebook with at least one source. Create one first.",
       "step1": {
         "title": "Type your question",
         "body": "AI cites exact passages so you can verify."
@@ -519,6 +522,7 @@
     "wikiGraph": {
       "title": "Wiki knowledge graph",
       "summary": "Auto-built wiki of entities, concepts, and connections.",
+      "prereq": "Needs a notebook with sources so the wiki has something to build.",
       "step1": {
         "title": "Wiki tab",
         "body": "SparkFlow builds a wiki from your sources as they're added."
@@ -539,6 +543,7 @@
     "notes": {
       "title": "Notes",
       "summary": "Personal markdown notes attached to a notebook.",
+      "prereq": "Needs an existing notebook. Create one first.",
       "step1": {
         "title": "Notes tab",
         "body": "Your markdown alongside the AI output."

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -431,7 +431,8 @@
     "action": {
       "play": "播放演示",
       "read": "阅读",
-      "dismiss": "不再显示"
+      "dismiss": "不再显示",
+      "setupFirst": "先去准备"
     },
     "tour": {
       "welcomeTitle": "欢迎使用 SparkFlow",
@@ -467,6 +468,7 @@
     "addSources": {
       "title": "添加资料",
       "summary": "支持文件、文件夹、URL,一次最多 50 份。",
+      "prereq": "需要先有一个 notebook,请先创建。",
       "step1": {
         "title": "我们来添加资料",
         "body": "先跳到你最近的 notebook,再一步步走 Add Source 对话框。"
@@ -503,6 +505,7 @@
     "chatWithAi": {
       "title": "与 AI 对话",
       "summary": "基于你的资料提问,回答附带原文引用。",
+      "prereq": "需要一个至少含一份资料的 notebook,请先创建。",
       "step1": {
         "title": "输入问题",
         "body": "AI 引用原文段落,方便核对。"
@@ -519,6 +522,7 @@
     "wikiGraph": {
       "title": "Wiki 知识图谱",
       "summary": "基于资料自动构建的实体、概念和关联。",
+      "prereq": "需要 notebook 中已有资料,Wiki 才有内容可构建。",
       "step1": {
         "title": "Wiki Tab",
         "body": "资料加入后,SparkFlow 自动构建 wiki。"
@@ -539,6 +543,7 @@
     "notes": {
       "title": "笔记",
       "summary": "附在 notebook 上的个人 markdown 笔记。",
+      "prereq": "需要先有一个 notebook,请先创建。",
       "step1": {
         "title": "Notes Tab",
         "body": "你的 markdown 和 AI 输出并列。"

--- a/apps/web/prisma/migrations/20260426120000_add_welcome_pending/migration.sql
+++ b/apps/web/prisma/migrations/20260426120000_add_welcome_pending/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "welcomePending" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   updatedAt    DateTime @updatedAt
 
   tourCompletedAt DateTime?
+  welcomePending  Boolean   @default(false)
   dismissedGuides String[]  @default([])
 
   // Relations
@@ -69,28 +70,28 @@ model Session {
 
 // User preferences for AI model selection
 model UserSettings {
-  id                  String   @id @default(cuid())
-  userId              String   @unique
+  id                      String   @id @default(cuid())
+  userId                  String   @unique
   // Deepdive — Chat/RAG agent model
-  modelProvider       String   @default("openai")
-  modelName           String   @default("gpt-4o-mini")
+  modelProvider           String   @default("openai")
+  modelName               String   @default("gpt-4o-mini")
   // Deepdive — Wiki generation model
-  wikiModelProvider   String   @default("openai")
-  wikiModelName       String   @default("gpt-4o-mini")
+  wikiModelProvider       String   @default("openai")
+  wikiModelName           String   @default("gpt-4o-mini")
   // Deepdive — Source search agent model
-  searchModelProvider  String   @default("openai")
-  searchModelName      String   @default("gpt-4o-mini")
+  searchModelProvider     String   @default("openai")
+  searchModelName         String   @default("gpt-4o-mini")
   // Research Hub — SemOps agent model (formerly matcher)
-  semopsModelProvider String  @default("openai")
-  semopsModelName    String   @default("gpt-4o-mini")
+  semopsModelProvider     String   @default("openai")
+  semopsModelName         String   @default("gpt-4o-mini")
   // BYOK — encrypted JSON blob of API keys per provider
-  apiKeys             String?  @db.Text
+  apiKeys                 String?  @db.Text
   // WeChat — excluded source IDs for Add Source search (empty = all)
-  wechatExcludedSourceIds Int[]   @default([])
+  wechatExcludedSourceIds Int[]    @default([])
   // Daily Digest — user query + source configuration
-  digestConfig        Json     @default("{}")
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  digestConfig            Json     @default("{}")
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -112,7 +113,7 @@ model Notebook {
   updatedAt DateTime @updatedAt
 
   // Relations
-  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   sources      Source[]
   chatSessions ChatSession[]
   messages     ChatMessage[]
@@ -175,7 +176,7 @@ model SourceImage {
   id           String   @id @default(cuid())
   sourceId     String
   originalName String // Original filename (e.g., "image_0.png")
-  data         Bytes  // Raw image binary (bytea)
+  data         Bytes // Raw image binary (bytea)
   mimeType     String // MIME type (e.g., "image/png")
   width        Int?
   height       Int?
@@ -195,7 +196,7 @@ model WikiPage {
   title      String
   content    String       @db.Text
   pageType   WikiPageType
-  sourceRefs String[]     // Source IDs that contributed to this page
+  sourceRefs String[] // Source IDs that contributed to this page
   createdAt  DateTime     @default(now())
   updatedAt  DateTime     @updatedAt
 
@@ -209,11 +210,12 @@ model WikiPage {
 model NotebookGraph {
   id          String   @id @default(cuid())
   notebookId  String   @unique
-  graphData   Json     // {nodes: [...], edges: [...]}
-  communities Json     // {community_id: [node_ids]}
+  graphData   Json // {nodes: [...], edges: [...]}
+  communities Json // {community_id: [node_ids]}
   updatedAt   DateTime @updatedAt
 
   notebook Notebook @relation(fields: [notebookId], references: [id], onDelete: Cascade)
+
   @@map("notebook_graphs")
 }
 
@@ -305,38 +307,38 @@ model Note {
 // ============================================
 
 model Venue {
-  id          String     @id @default(cuid())
-  name        String     @unique
+  id          String  @id @default(cuid())
+  name        String  @unique
   type        String?
   description String?
 
-  instances   Instance[]
+  instances Instance[]
 
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@map("venues")
 }
 
 model Instance {
-  id          String               @id @default(cuid())
-  venueId     String
-  venue       Venue                @relation(fields: [venueId], references: [id])
+  id      String @id @default(cuid())
+  venueId String
+  venue   Venue  @relation(fields: [venueId], references: [id])
 
-  year        Int
-  name        String
-  startDate   DateTime?
-  endDate     DateTime?
-  location    String?
-  website     String?
-  summary     String?              @db.Text
+  year      Int
+  name      String
+  startDate DateTime?
+  endDate   DateTime?
+  location  String?
+  website   String?
+  summary   String?   @db.Text
 
   publications Publication[]
   sessions     ConferenceSession[]
   matchJobs    MatchJob[]
 
-  createdAt   DateTime             @default(now())
-  updatedAt   DateTime             @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@unique([venueId, year])
   @@index([year])
@@ -344,36 +346,36 @@ model Instance {
 }
 
 model Publication {
-  id            String                 @id @default(cuid())
-  instanceId    String
-  instance      Instance               @relation(fields: [instanceId], references: [id])
+  id         String   @id @default(cuid())
+  instanceId String
+  instance   Instance @relation(fields: [instanceId], references: [id])
 
-  title         String
-  authors       String[]
-  abstract      String?                @db.Text
-  summary       String?                @db.Text
+  title    String
+  authors  String[]
+  abstract String?  @db.Text
+  summary  String?  @db.Text
 
   affiliations  String[]
   countries     String[]
   keywords      String[]
   researchTopic String?
 
-  rating        Float?
-  doi           String?
-  pdfUrl        String?
-  githubUrl     String?
-  websiteUrl    String?
-  status        String?
+  rating     Float?
+  doi        String?
+  pdfUrl     String?
+  githubUrl  String?
+  websiteUrl String?
+  status     String?
 
   // BGE-M3 (1024-dim) embeddings for agent prefilter — indexed via HNSW in a
   // raw-SQL migration step. Populated by the backfill script in apps/agent.
   titleEmbedding    Unsupported("vector(1024)")?
   abstractEmbedding Unsupported("vector(1024)")?
 
-  sessions      SessionPublication[]
+  sessions SessionPublication[]
 
-  createdAt     DateTime               @default(now())
-  updatedAt     DateTime               @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([instanceId])
   @@index([researchTopic])
@@ -395,35 +397,35 @@ model WechatArticleEmbedding {
 }
 
 model ConferenceSession {
-  id          String                 @id @default(cuid())
-  instanceId  String
-  instance    Instance               @relation(fields: [instanceId], references: [id])
+  id         String   @id @default(cuid())
+  instanceId String
+  instance   Instance @relation(fields: [instanceId], references: [id])
 
-  title       String
-  type        String?
-  date        DateTime?
-  startTime   String?
-  endTime     String?
-  location    String?
-  speaker     String[]               @default([])
+  title     String
+  type      String?
+  date      DateTime?
+  startTime String?
+  endTime   String?
+  location  String?
+  speaker   String[]  @default([])
 
-  abstract    String?                @db.Text
-  overview    String?                @db.Text
-  transcript  String?                @db.Text
-  sessionUrl  String?
+  abstract   String? @db.Text
+  overview   String? @db.Text
+  transcript String? @db.Text
+  sessionUrl String?
 
-  topic       String[]               @default([])
-  affiliation String[]               @default([])
-  technology  String[]               @default([])
+  topic       String[] @default([])
+  affiliation String[] @default([])
+  technology  String[] @default([])
 
   sessionFormat    SessionFormat?
-  hasRecording     Boolean           @default(false)
+  hasRecording     Boolean        @default(false)
   intendedAudience String?
 
   publications SessionPublication[]
 
-  createdAt   DateTime               @default(now())
-  updatedAt   DateTime               @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([instanceId])
   @@index([type])
@@ -460,27 +462,27 @@ enum MatchTargetType {
 }
 
 model MatchJob {
-  id              String           @id @default(cuid())
-  userId          String
-  instanceId      String           // Conference instance to match against
-  targetType      MatchTargetType  // SESSION or PUBLICATION
-  topK            Int              @default(50)
-  searchK         Int              @default(350)
-  includeReasons  Boolean          @default(true)
-  queryFileKey    String           // S3 key for uploaded Excel
-  queryData       Json?            // Parsed queries (cached)
-  resultFileKey   String?          // S3 key for result Excel
-  status          MatchJobStatus   @default(PENDING)
-  progress        Int              @default(0)
-  errorMessage    String?
-  queryCount      Int              @default(0)
-  matchCount      Int              @default(0)
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
-  startedAt       DateTime?
-  completedAt     DateTime?
+  id             String          @id @default(cuid())
+  userId         String
+  instanceId     String // Conference instance to match against
+  targetType     MatchTargetType // SESSION or PUBLICATION
+  topK           Int             @default(50)
+  searchK        Int             @default(350)
+  includeReasons Boolean         @default(true)
+  queryFileKey   String // S3 key for uploaded Excel
+  queryData      Json? // Parsed queries (cached)
+  resultFileKey  String? // S3 key for result Excel
+  status         MatchJobStatus  @default(PENDING)
+  progress       Int             @default(0)
+  errorMessage   String?
+  queryCount     Int             @default(0)
+  matchCount     Int             @default(0)
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  startedAt      DateTime?
+  completedAt    DateTime?
 
-  instance        Instance         @relation(fields: [instanceId], references: [id], onDelete: Cascade)
+  instance Instance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([status])
@@ -494,7 +496,7 @@ model MatchJob {
 model UserMemory {
   id        String   @id @default(cuid())
   userId    String
-  category  String   // "profile" | "preference" | "fact" | "feedback"
+  category  String // "profile" | "preference" | "fact" | "feedback"
   content   String   @db.Text
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -524,13 +526,13 @@ model NotebookMemory {
 // ============================================
 
 model DailyDigest {
-  id          String          @id @default(cuid())
+  id          String   @id @default(cuid())
   userId      String
-  digestDate  DateTime        @db.Date
-  generatedAt DateTime        @default(now())
+  digestDate  DateTime @db.Date
+  generatedAt DateTime @default(now())
 
-  user        User            @relation(fields: [userId], references: [id], onDelete: Cascade)
-  sections    DigestSection[]
+  user     User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  sections DigestSection[]
 
   @@unique([userId, digestDate])
   @@index([userId, digestDate(sort: Desc)])
@@ -538,18 +540,18 @@ model DailyDigest {
 }
 
 model DigestSection {
-  id            String            @id @default(cuid())
+  id            String           @id @default(cuid())
   digestId      String
   sourceType    DigestSourceType
-  status        DigestStatus      @default(GENERATING)
-  items         Json              @default("[]")
-  candidatePool Int               @default(0)
+  status        DigestStatus     @default(GENERATING)
+  items         Json             @default("[]")
+  candidatePool Int              @default(0)
   modelUsed     String?
   error         String?
-  startedAt     DateTime          @default(now())
+  startedAt     DateTime         @default(now())
   completedAt   DateTime?
 
-  digest        DailyDigest       @relation(fields: [digestId], references: [id], onDelete: Cascade)
+  digest DailyDigest @relation(fields: [digestId], references: [id], onDelete: Cascade)
 
   @@unique([digestId, sourceType])
   @@map("digest_section")


### PR DESCRIPTION
… hints

Welcome modal now auto-prompts only after fresh signup, not on every login of an existing user. New User.welcomePending boolean (default false, true on signup) gates the welcome; Skip / Start clears it; the drawer's "Replay tour" button re-arms it and clears local progress so the modal returns in the same session without a reload.

First-run tour trimmed to four no-prerequisite steps a brand-new user can actually complete: create-notebook → BYOK → conferences → matcher. add-sources / chat-with-ai dropped — both required an existing notebook.

Single guides with preconditions (add-sources, chat-with-ai, wiki-graph, notes) now declare a prereq { hintKey, setupGuideId } and render an amber "Set up first" button in the drawer that immediately launches the prerequisite guide.

Internals:
- Extracted shared positioning + overlay lifecycle into components/guides/ lib.ts and use-guide-overlay.ts; cuts ~235 lines of duplication between Spotlight and GuideLayer.
- Replaced the 1.5s 60fps rAF position tracker with a ResizeObserver + MutationObserver + scroll/resize listeners (and a 400ms initial settle). Tracks past 1.5s, near-zero idle cost.
- Bubble position clamped to viewport so it never overflows the screen.
- prefers-reduced-motion honored — overlays drop the spring overshoot in favour of a 150ms tween.

Migration: prisma/migrations/20260426120000_add_welcome_pending/. Apply locally with npx prisma migrate dev; production with npx prisma migrate deploy.