### PR TITLE
feat(agent): allow `make up` to use an external Postgres via env var

### DIFF
--- a/apps/agent/Makefile
+++ b/apps/agent/Makefile
@@ -18,6 +18,18 @@ else
 COMPOSE_FLAG :=
 endif
 
+# Optional: point langgraph at an external Postgres instead of the
+# CLI-managed sibling container. Set on hosts where Docker's embedded
+# DNS can't resolve compose siblings (corp networks, deeply nested
+# docker setups, etc.). Use the host postgres reachable via
+# host.docker.internal — the override ensures that name resolves on Linux.
+#   make up LANGGRAPH_POSTGRES_URI="postgresql://user:pass@host.docker.internal:5433/langgraph"
+ifneq ($(LANGGRAPH_POSTGRES_URI),)
+POSTGRES_FLAG := --postgres-uri "$(LANGGRAPH_POSTGRES_URI)"
+else
+POSTGRES_FLAG :=
+endif
+
 .PHONY: dev serve up up-fresh build build-from-scratch stop logs test clean help
 
 help:
@@ -46,7 +58,7 @@ serve:
 # Daily Docker path. Lets the CLI build + run in one shot — Docker layer
 # cache makes repeats fast.
 up:
-	langgraph up --port $(PORT) $(COMPOSE_FLAG)
+	langgraph up --port $(PORT) $(POSTGRES_FLAG) $(COMPOSE_FLAG)
 
 # Rebuild after editing requirements/pyproject.toml. We do NOT pass
 # `--no-cache` — Docker's content-addressed layer cache busts the deps
@@ -56,7 +68,7 @@ up:
 # bumps. Use `make build-from-scratch` if you genuinely want fresh base.
 up-fresh:
 	langgraph build -t $(IMAGE_TAG)
-	langgraph up --image $(IMAGE_TAG) --port $(PORT) $(COMPOSE_FLAG)
+	langgraph up --image $(IMAGE_TAG) --port $(PORT) $(POSTGRES_FLAG) $(COMPOSE_FLAG)
 
 # Standalone build — useful in CI, or to pre-warm the cache before `up`.
 build:

--- a/apps/agent/README.md
+++ b/apps/agent/README.md
@@ -77,6 +77,25 @@ the running version with `docker logs langgraph-api-1 | head` (look for
 ```
 Bump explicitly when ready to upgrade.
 
+### External Postgres (skip the CLI's sibling postgres container)
+
+On hosts where Docker's embedded DNS misbehaves and `langgraph-api`
+can't resolve `langgraph-postgres`, point `langgraph up` at an existing
+Postgres instead of letting the CLI run one for you:
+
+```bash
+# One-time: create a dedicated DB on the host postgres (port 5433)
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -p 5433 -U postgres \
+  -c "CREATE DATABASE langgraph;"
+
+# Run langgraph against it
+make up LANGGRAPH_POSTGRES_URI="postgresql://postgres:$POSTGRES_PASSWORD@host.docker.internal:5433/langgraph"
+```
+
+The `docker-compose.override.yml` adds `host.docker.internal:host-gateway`
+so that hostname resolves on Linux (Docker Desktop on Mac/Win does it
+automatically). No more sibling-DNS dependency on this path.
+
 ### Corporate CA bundle (runtime mount, NOT baked)
 
 The `langgraph-api` image is built by `langgraph build` from the upstream

--- a/apps/agent/docker-compose.override.yml.example
+++ b/apps/agent/docker-compose.override.yml.example
@@ -10,7 +10,13 @@
 #  * The cert is host-specific anyway (different CAs per environment).
 #  * Mounting needs no rebuild; replace the cert and `make stop && make up`.
 
-x-ca-bundle: &ca-bundle
+x-host-extras: &host-extras
+  # Make `host.docker.internal` resolvable from inside the container on
+  # Linux (it's automatic on Docker Desktop). Lets us point
+  # `--postgres-uri` at a Postgres listening on the host port 5433
+  # without depending on Docker's embedded DNS resolving sibling names.
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
   volumes:
     - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
   environment:
@@ -22,8 +28,8 @@ x-ca-bundle: &ca-bundle
 
 services:
   langgraph-api:
-    <<: *ca-bundle
+    <<: *host-extras
 
   # Uncomment if your compose stack also runs the digest worker as a sibling.
   # digest-worker:
-  #   <<: *ca-bundle
+  #   <<: *host-extras


### PR DESCRIPTION
When Docker's embedded DNS misbehaves (the production server we hit today couldn't resolve `langgraph-postgres` from inside `langgraph-api`), the cleanest workaround is to skip the CLI-managed sibling Postgres entirely and point at an external one. Add the wiring:

* Makefile: if LANGGRAPH_POSTGRES_URI is set, append `--postgres-uri "<value>"` to `make up` / `make up-fresh`. Default behaviour unchanged.
* docker-compose.override.yml.example: add `extra_hosts: ["host.docker.internal:host-gateway"]` so that hostname resolves on Linux (Docker Desktop already maps it). Lets the URI use `host.docker.internal:5433` to reach a host-side Postgres.
* README: document the create-database + `make up LANGGRAPH_POSTGRES_URI=...` flow.

Usage:
    make up LANGGRAPH_POSTGRES_URI="postgresql://user:pw@host.docker.internal:5433/langgraph"