### PR TITLE
chore(agent): drop DNS-debugging workarounds

### DIFF
--- a/apps/agent/.gitignore
+++ b/apps/agent/.gitignore
@@ -208,9 +208,6 @@ __marimo__/
 
 .claude/
 .langgraph_api/
-# Host-specific corporate CA bundle, mounted at runtime via
-# docker-compose.override.yml (see docker-compose.override.yml.example).
-# NOT baked into the langgraph-api image — that image is built from the
-# upstream wolfi base by `langgraph build`, so we leave it untouched.
+# Host-specific overrides for `langgraph up -d` (CA cert + env tweaks).
 ca-certificates.crt
 docker-compose.override.yml

--- a/apps/agent/Makefile
+++ b/apps/agent/Makefile
@@ -9,8 +9,7 @@ export DOCKER_BUILDKIT := 1
 export COMPOSE_DOCKER_CLI_BUILD := 1
 
 # Auto-attach docker-compose.override.yml if present on this host
-# (mounts CA cert, sets SSL_CERT_FILE / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE
-# and LANGGRAPH_API_HOST=0.0.0.0).
+# (mounts CA cert + sets corp-network env vars).
 COMPOSE_OVERRIDE := $(wildcard docker-compose.override.yml)
 ifneq ($(COMPOSE_OVERRIDE),)
 COMPOSE_FLAG := -d $(COMPOSE_OVERRIDE)
@@ -18,70 +17,39 @@ else
 COMPOSE_FLAG :=
 endif
 
-# Optional: point langgraph at an external Postgres instead of the
-# CLI-managed sibling container. Set on hosts where Docker's embedded
-# DNS can't resolve compose siblings (corp networks, deeply nested
-# docker setups, etc.). Use the host postgres reachable via
-# host.docker.internal — the override ensures that name resolves on Linux.
-#   make up LANGGRAPH_POSTGRES_URI="postgresql://user:pass@host.docker.internal:5433/langgraph"
-ifneq ($(LANGGRAPH_POSTGRES_URI),)
-POSTGRES_FLAG := --postgres-uri "$(LANGGRAPH_POSTGRES_URI)"
-else
-POSTGRES_FLAG :=
-endif
-
-.PHONY: dev serve up up-fresh build build-from-scratch stop logs test clean help
+.PHONY: dev serve up up-fresh build stop logs test clean help
 
 help:
 	@echo "Targets:"
-	@echo "  dev                - In-process LangGraph dev server (no Docker, hot reload)"
-	@echo "  serve              - FastAPI workflows server (matcher / digest / search)"
-	@echo "  up                 - Start postgres/redis + agent (auto-uses override if present)"
-	@echo "  up-fresh           - Rebuild image (deps changed) then start"
-	@echo "  build              - Standalone: build $(IMAGE_TAG), don't start"
-	@echo "  build-from-scratch - Full --no-cache --pull rebuild (escape hatch)"
-	@echo "  stop               - Stop the langgraph compose stack"
-	@echo "  logs               - Tail logs from the langgraph-api container"
-	@echo "  test               - Run pytest"
-	@echo "  clean              - Remove the prebuilt image"
+	@echo "  dev       - In-process LangGraph dev server (no Docker, hot reload)"
+	@echo "  serve     - FastAPI workflows server (matcher / digest / search)"
+	@echo "  up        - Start postgres/redis + agent (auto-uses override if present)"
+	@echo "  up-fresh  - --no-cache rebuild then start (after editing deps)"
+	@echo "  build     - Standalone: build $(IMAGE_TAG), don't start"
+	@echo "  stop      - Stop the langgraph compose stack"
+	@echo "  logs      - Tail logs from the langgraph-api container"
+	@echo "  test      - Run pytest"
+	@echo "  clean     - Remove the prebuilt image"
 
-# Fastest path: in-process, hot reload. Use this for daily development.
 dev:
 	langgraph dev --host 0.0.0.0 --port $(PORT)
 
 # FastAPI workflows server. Runs alongside `langgraph dev` (different port).
-# Hosts /v1/workflows/matcher/jobs, /v1/workflows/daily_digest/sections/*,
-# and /v1/workflows/search — consumed by apps/web's API routes.
 serve:
 	uvicorn server.app:app --host 0.0.0.0 --port $(WORKFLOWS_PORT) --reload
 
-# Daily Docker path. Lets the CLI build + run in one shot — Docker layer
-# cache makes repeats fast.
 up:
-	langgraph up --port $(PORT) $(POSTGRES_FLAG) $(COMPOSE_FLAG)
+	langgraph up --port $(PORT) $(COMPOSE_FLAG)
 
-# Rebuild after editing requirements/pyproject.toml. We do NOT pass
-# `--no-cache` — Docker's content-addressed layer cache busts the deps
-# layer automatically when pyproject.toml changes, and `--no-cache`
-# combined with `langgraph build`'s default `--pull` re-fetches the
-# wolfi base image, which has caused DNS misbehaviour after upstream
-# bumps. Use `make build-from-scratch` if you genuinely want fresh base.
 up-fresh:
-	langgraph build -t $(IMAGE_TAG)
-	langgraph up --image $(IMAGE_TAG) --port $(PORT) $(POSTGRES_FLAG) $(COMPOSE_FLAG)
+	langgraph build --no-cache -t $(IMAGE_TAG)
+	langgraph up --image $(IMAGE_TAG) --port $(PORT) $(COMPOSE_FLAG)
 
-# Standalone build — useful in CI, or to pre-warm the cache before `up`.
 build:
 	langgraph build -t $(IMAGE_TAG)
 
-# Escape hatch: full --no-cache --pull rebuild. Only when you specifically
-# want the latest upstream base image.
-build-from-scratch:
-	langgraph build --no-cache --pull -t $(IMAGE_TAG)
-
 # `langgraph` has no `down` subcommand. Stop containers via docker compose
-# project name. The CLI launches under the project named after the parent
-# directory of langgraph.json (i.e. apps/agent → "agent").
+# project label.
 stop:
 	-docker ps --filter "label=com.docker.compose.project" --format '{{.Label "com.docker.compose.project"}}' \
 		| sort -u | grep -i langgraph \

--- a/apps/agent/README.md
+++ b/apps/agent/README.md
@@ -77,25 +77,6 @@ the running version with `docker logs langgraph-api-1 | head` (look for
 ```
 Bump explicitly when ready to upgrade.
 
-### External Postgres (skip the CLI's sibling postgres container)
-
-On hosts where Docker's embedded DNS misbehaves and `langgraph-api`
-can't resolve `langgraph-postgres`, point `langgraph up` at an existing
-Postgres instead of letting the CLI run one for you:
-
-```bash
-# One-time: create a dedicated DB on the host postgres (port 5433)
-PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -p 5433 -U postgres \
-  -c "CREATE DATABASE langgraph;"
-
-# Run langgraph against it
-make up LANGGRAPH_POSTGRES_URI="postgresql://postgres:$POSTGRES_PASSWORD@host.docker.internal:5433/langgraph"
-```
-
-The `docker-compose.override.yml` adds `host.docker.internal:host-gateway`
-so that hostname resolves on Linux (Docker Desktop on Mac/Win does it
-automatically). No more sibling-DNS dependency on this path.
-
 ### Corporate CA bundle (runtime mount, NOT baked)
 
 The `langgraph-api` image is built by `langgraph build` from the upstream

--- a/apps/agent/docker-compose.override.yml.example
+++ b/apps/agent/docker-compose.override.yml.example
@@ -1,35 +1,17 @@
-# Optional override consumed by `langgraph up -d docker-compose.override.yml`.
-# Activate on a host:
+# Optional override for `langgraph up -d docker-compose.override.yml`.
+# Activate on a host that needs a corporate CA bundle:
 #   cp docker-compose.override.yml.example docker-compose.override.yml
+#   cp /path/to/your-ca.crt ./ca-certificates.crt
 #   make up
 # (apps/agent/Makefile auto-attaches the file with `-d` when it exists.)
-#
-# Why mount instead of baking into the image:
-#  * `langgraph build` pulls the upstream wolfi base — modifying that
-#    image risks netconfig drift when the base bumps.
-#  * The cert is host-specific anyway (different CAs per environment).
-#  * Mounting needs no rebuild; replace the cert and `make stop && make up`.
-
-x-host-extras: &host-extras
-  # Make `host.docker.internal` resolvable from inside the container on
-  # Linux (it's automatic on Docker Desktop). Lets us point
-  # `--postgres-uri` at a Postgres listening on the host port 5433
-  # without depending on Docker's embedded DNS resolving sibling names.
-  extra_hosts:
-    - "host.docker.internal:host-gateway"
-  volumes:
-    - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
-  environment:
-    # Three env vars cover every Python TLS path: ssl module, requests, libcurl.
-    SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
-    REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
-    CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
-    LANGGRAPH_API_HOST: 0.0.0.0
 
 services:
   langgraph-api:
-    <<: *host-extras
-
-  # Uncomment if your compose stack also runs the digest worker as a sibling.
-  # digest-worker:
-  #   <<: *host-extras
+    volumes:
+      - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+    environment:
+      # Three env vars cover every Python TLS path: ssl module, requests, libcurl.
+      SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+      CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+      LANGGRAPH_API_HOST: 0.0.0.0


### PR DESCRIPTION
## Summary

Follow-up cleanup to PR #114. The DNS error we were chasing (`server misbehaving on 127.0.0.11:53`) turned out to be a **stale `langgraph-postgres` container** left behind from a previous compose run, not a Docker daemon DNS issue or upstream wolfi base bump. Once the stale container was removed, plain \`make up\` started cleanly.

This PR strips the speculative workarounds we accumulated chasing the wrong hypothesis.

## What's removed

- \`LANGGRAPH_POSTGRES_URI\` / \`POSTGRES_FLAG\` Makefile variables — external Postgres workaround was never needed.
- \`build-from-scratch\` Makefile target — the "fresh base bump caused DNS drift" theory was wrong.
- \`extra_hosts: host.docker.internal:host-gateway\` from the override — was paired with the external-Postgres flow.
- \`x-host-extras\` YAML anchor + commented-out \`digest-worker\` stub — no longer needed.
- "External Postgres" section from the README.
- Long-form CA-bundle comment in \`.gitignore\`.

## What stays

- \`docker-compose.override.yml.example\` mounts the corp CA cert at \`/etc/ssl/certs/ca-certificates.crt\` and sets \`SSL_CERT_FILE\` / \`REQUESTS_CA_BUNDLE\` / \`CURL_CA_BUNDLE\` + \`LANGGRAPH_API_HOST=0.0.0.0\`. That's the only host-specific thing prod actually needs.
- Original \`make up-fresh\` semantics restored (\`langgraph build --no-cache -t … && langgraph up --image …\`).

Net diff: **27 added, 99 removed**.

## Test plan

- [x] \`make up\` starts cleanly on the production server after wiping stale containers
- [x] CA cert mounted at \`/etc/ssl/certs/ca-certificates.crt\` inside \`langgraph-api-1\`
- [x] Three TLS env vars present in the container
- [ ] Production verifies LangGraph chat works end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)