### PR TITLE
chore(agent): add NO_PROXY to override, mirroring apps/web

### DIFF
--- a/apps/agent/docker-compose.override.yml.example
+++ b/apps/agent/docker-compose.override.yml.example
@@ -15,3 +15,9 @@ services:
       REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       LANGGRAPH_API_HOST: 0.0.0.0
+      # On hosts where ~/.docker/config.json injects HTTP_PROXY/HTTPS_PROXY into
+      # every container (corp networks), NO_PROXY must list every sibling
+      # service hostname so postgres/redis traffic doesn't get proxied. Both
+      # cases written: requests/httpx read NO_PROXY, libcurl reads no_proxy.
+      NO_PROXY: ${NO_PROXY:-localhost,127.0.0.1},langgraph-postgres,langgraph-redis,langgraph-api
+      no_proxy: ${no_proxy:-localhost,127.0.0.1},langgraph-postgres,langgraph-redis,langgraph-api


### PR DESCRIPTION
On hosts where ~/.docker/config.json auto-injects HTTP_PROXY into every container, sibling-to-sibling traffic (langgraph-api → postgres / redis) gets routed through the corp HTTP proxy unless we exempt those hostnames in NO_PROXY. Web compose already does this; the agent override needs the same treatment.

* Add NO_PROXY / no_proxy entries listing the three langgraph siblings, defaulting from \$NO_PROXY (so the line is still safe on hosts without a proxy — the value gracefully degrades to localhost,127.0.0.1).
* Both upper- and lower-case forms because requests/httpx read NO_PROXY while libcurl reads no_proxy.

HTTP_PROXY / HTTPS_PROXY themselves stay implicit — Docker's daemon config injects them automatically on hosts that have them configured.