### PR TITLE
chore(agent): align langgraph setup with CLI best practices

### DIFF
--- a/apps/agent/.env.example
+++ b/apps/agent/.env.example
@@ -34,6 +34,19 @@ INTERNAL_CALLBACK_TOKEN=dev_callback_token              # openssl rand -hex 32
 # apps/agent/scripts/. Must match apps/web/.env's DATABASE_URL.
 DATABASE_URL=postgresql://sparkflow:sparkflow@localhost:5433/sparkflow
 
+# LangGraph checkpointer DB — persists thread state / interrupts / resumes.
+# `langgraph dev` falls back to an in-memory saver when unset (fine for local
+# hot-reload). For `langgraph up`, leave UNSET to let the CLI spin up its own
+# `langgraph-postgres` sibling — UNLESS apps/web's compose is already running
+# postgres on host port 5433 (then the sibling fails to bind). In that case
+# uncomment this and reuse the web's postgres. Use `host.docker.internal`
+# because the langgraph-api container reaches the host network through it.
+# A separate database (sparkflow_checkpoints) is recommended so checkpoint
+# churn doesn't fight Prisma migrations; create it once with:
+#   docker exec -it sparkflow-postgres psql -U sparkflow -c \
+#     "CREATE DATABASE sparkflow_checkpoints;"
+# CHECKPOINT_DB_URL=postgresql://sparkflow:sparkflow@host.docker.internal:5433/sparkflow_checkpoints
+
 # Redis — shared with the web app's BullMQ queue. Used by ARQ digest worker.
 REDIS_URL=redis://localhost:6379
 

--- a/apps/agent/.env.production.example
+++ b/apps/agent/.env.production.example
@@ -43,6 +43,13 @@ INTERNAL_CALLBACK_TOKEN=__rotate_per_env__              # openssl rand -hex 32
 # service hostname. langgraph-api / host scripts use this value directly.
 DATABASE_URL=postgresql://sparkflow:__strong_random_password__@postgres:5432/sparkflow
 
+# LangGraph checkpointer DB — persists thread state / interrupts / resumes.
+# `langgraph up` auto-provisions a `langgraph-postgres` sibling by default;
+# set this to point checkpoints at your own Postgres instead (recommended in
+# prod for backups + cross-deployment durability). Use a dedicated DB or
+# schema so checkpoint churn doesn't fight the main DB's vacuum schedule.
+CHECKPOINT_DB_URL=postgresql://sparkflow:__strong_random_password__@postgres:5432/sparkflow_checkpoints
+
 # Redis — workflows-api / digest-worker get redis://redis:6379 injected
 # by compose. Outside compose, set to your real broker.
 REDIS_URL=redis://redis:6379

--- a/apps/agent/Makefile
+++ b/apps/agent/Makefile
@@ -2,7 +2,12 @@
 # Reference: https://docs.langchain.com/langsmith/cli
 
 IMAGE_TAG ?= sparkflow-agent:dev
-PORT ?= 2024
+# `langgraph dev` defaults to 2024 (lightweight, in-process); `langgraph up`
+# defaults to 8123 (production-like Docker stack). Same convention as the
+# upstream LangGraph CLI docs — keeps the two stacks runnable side-by-side
+# without port collisions.
+DEV_PORT ?= 2024
+UP_PORT ?= 8123
 WORKFLOWS_PORT ?= 2027
 
 export DOCKER_BUILDKIT := 1
@@ -17,33 +22,65 @@ else
 COMPOSE_FLAG :=
 endif
 
-.PHONY: dev serve up up-fresh build stop logs test clean help
+# Optional: point langgraph at an external Postgres for the checkpointer
+# instead of letting `langgraph up` spin up its own `langgraph-postgres`
+# sibling. Two scenarios where this is needed:
+#   1. Host port 5433 is already taken by `apps/web`'s postgres → langgraph's
+#      sibling fails to bind ("port is already allocated"). Reuse web's
+#      postgres via host.docker.internal:5433.
+#   2. You want checkpoints to persist across `make stop` / image rebuilds
+#      (langgraph's sibling lives in a CLI-managed volume that's easy to
+#      blow away accidentally).
+# When set, this is passed as `--postgres-uri` to `langgraph up`.
+# Read from .env automatically because `langgraph.json` declares `env: .env`,
+# but we ALSO surface it on the Make command line so the CLI sees it before
+# launching docker compose.
+ifneq ($(CHECKPOINT_DB_URL),)
+POSTGRES_FLAG := --postgres-uri "$(CHECKPOINT_DB_URL)"
+else
+POSTGRES_FLAG :=
+endif
+
+# LangGraph CLI workflow (per docs.langchain.com/langsmith/local-dev-testing):
+#   develop daily with `dev` → periodically validate with `up` → pre-deploy
+#   check with `up-recreate`. `dev` runs in-process (no Docker), `up` runs the
+#   full postgres/redis/agent stack in containers. On corp-network hosts where
+#   Docker's embedded DNS struggles with sibling resolution, prefer `dev`.
+.PHONY: dev serve up up-recreate up-fresh build stop logs test clean help
 
 help:
 	@echo "Targets:"
-	@echo "  dev       - In-process LangGraph dev server (no Docker, hot reload)"
-	@echo "  serve     - FastAPI workflows server (matcher / digest / search)"
-	@echo "  up        - Start postgres/redis + agent (auto-uses override if present)"
-	@echo "  up-fresh  - --no-cache rebuild then start (after editing deps)"
-	@echo "  build     - Standalone: build $(IMAGE_TAG), don't start"
-	@echo "  stop      - Stop the langgraph compose stack"
-	@echo "  logs      - Tail logs from the langgraph-api container"
-	@echo "  test      - Run pytest"
-	@echo "  clean     - Remove the prebuilt image"
+	@echo "  dev          - In-process LangGraph dev server on :$(DEV_PORT) (no Docker, hot reload, in-memory state)"
+	@echo "  serve        - FastAPI workflows server on :$(WORKFLOWS_PORT) (matcher / digest / search)"
+	@echo "  up           - Production-like Docker stack on :$(UP_PORT): postgres + redis + agent (auto-uses override if present)"
+	@echo "  up-recreate  - up + --recreate: force fresh container recreation (pre-deploy / fix stale containers)"
+	@echo "  up-fresh     - --no-cache image rebuild then start (after editing deps)"
+	@echo "  build        - Standalone: build $(IMAGE_TAG), don't start"
+	@echo "  stop         - Stop the langgraph compose stack"
+	@echo "  logs         - Tail logs from the langgraph-api container"
+	@echo "  test         - Run pytest"
+	@echo "  clean        - Remove the prebuilt image"
 
 dev:
-	langgraph dev --host 0.0.0.0 --port $(PORT)
+	langgraph dev --host 0.0.0.0 --port $(DEV_PORT)
 
 # FastAPI workflows server. Runs alongside `langgraph dev` (different port).
 serve:
 	uvicorn server.app:app --host 0.0.0.0 --port $(WORKFLOWS_PORT) --reload
 
 up:
-	langgraph up --port $(PORT) $(COMPOSE_FLAG)
+	langgraph up --port $(UP_PORT) $(POSTGRES_FLAG) $(COMPOSE_FLAG)
+
+# Pre-deployment validation per LangGraph docs: forces fresh container
+# recreation. Use this when a previous compose run left stale postgres /
+# redis containers around — symptom is `langgraph-postgres` resolving to
+# the wrong container or `psycopg_pool.PoolTimeout` at startup.
+up-recreate:
+	langgraph up --recreate --port $(UP_PORT) $(POSTGRES_FLAG) $(COMPOSE_FLAG)
 
 up-fresh:
 	langgraph build --no-cache -t $(IMAGE_TAG)
-	langgraph up --image $(IMAGE_TAG) --port $(PORT) $(COMPOSE_FLAG)
+	langgraph up --image $(IMAGE_TAG) --port $(UP_PORT) $(POSTGRES_FLAG) $(COMPOSE_FLAG)
 
 build:
 	langgraph build -t $(IMAGE_TAG)

--- a/apps/agent/README.md
+++ b/apps/agent/README.md
@@ -59,12 +59,47 @@ make logs        # tail langgraph-api logs
 `LANGGRAPH_CLOUD_LICENSE_KEY` in production). Make sure both live in
 `apps/agent/.env`. `make dev` does not need a LangSmith key.
 
-The default port for `langgraph up` is `8123`; we override to `2024` in
-the Makefile so it matches `langgraph dev` and `apps/web/.env`'s
-`LANGGRAPH_API_URL=http://localhost:2024`. Set `PORT=...` to override:
+Ports follow the upstream LangGraph CLI convention so the two stacks can
+run side-by-side without colliding:
+
+- `make dev` → `:2024` (matches `apps/web/.env`'s `LANGGRAPH_API_URL` default,
+  so daily dev "just works")
+- `make up` / `up-recreate` / `up-fresh` → `:8123` (matches `langgraph up`'s
+  upstream default; point `LANGGRAPH_API_URL` at it when validating with the
+  Docker stack)
+
+Override either port at the make invocation:
 ```bash
-make up PORT=8123
+make dev DEV_PORT=2030
+make up  UP_PORT=2024     # if you want it on 2024 instead
 ```
+
+### Postgres port conflict with `apps/web`
+
+`langgraph up` spins up its own `langgraph-postgres` sibling that wants
+host port `5433`. `apps/web/docker-compose.yml` already maps host `5433`
+to its own postgres, so running both at the same time fails with:
+
+```
+Bind for 0.0.0.0:5433 failed: port is already allocated
+```
+
+The fix is to point langgraph at the web's postgres instead of letting
+the CLI start its own. Set `CHECKPOINT_DB_URL` in `apps/agent/.env`
+(the Makefile passes it to `langgraph up` as `--postgres-uri`):
+
+```bash
+# One-time: create a dedicated DB so checkpoint churn doesn't fight Prisma
+docker exec -it sparkflow-postgres psql -U sparkflow -c \
+  "CREATE DATABASE sparkflow_checkpoints;"
+
+# In apps/agent/.env:
+CHECKPOINT_DB_URL=postgresql://sparkflow:sparkflow@host.docker.internal:5433/sparkflow_checkpoints
+```
+
+Requires `docker-compose.override.yml` to be active so
+`host.docker.internal` resolves from inside the container (the override
+adds it via `extra_hosts: host-gateway`).
 
 ### Optional: pin the LangGraph API server version
 

--- a/apps/agent/docker-compose.override.yml.example
+++ b/apps/agent/docker-compose.override.yml.example
@@ -7,6 +7,13 @@
 
 services:
   langgraph-api:
+    # Make `host.docker.internal` resolvable from inside the container on
+    # Linux (it's automatic on Docker Desktop). Required when CHECKPOINT_DB_URL
+    # points at apps/web's postgres via host.docker.internal:5433 to avoid the
+    # 5433 port-allocation conflict between web's postgres and langgraph's
+    # auto-managed sibling. Harmless on hosts that don't use it.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
     environment:
@@ -19,5 +26,7 @@ services:
       # every container (corp networks), NO_PROXY must list every sibling
       # service hostname so postgres/redis traffic doesn't get proxied. Both
       # cases written: requests/httpx read NO_PROXY, libcurl reads no_proxy.
-      NO_PROXY: ${NO_PROXY:-localhost,127.0.0.1},langgraph-postgres,langgraph-redis,langgraph-api
-      no_proxy: ${no_proxy:-localhost,127.0.0.1},langgraph-postgres,langgraph-redis,langgraph-api
+      # `host.docker.internal` is included so checkpointer traffic to apps/web's
+      # postgres doesn't get proxied either.
+      NO_PROXY: ${NO_PROXY:-localhost,127.0.0.1},langgraph-postgres,langgraph-redis,langgraph-api,host.docker.internal
+      no_proxy: ${no_proxy:-localhost,127.0.0.1},langgraph-postgres,langgraph-redis,langgraph-api,host.docker.internal

--- a/apps/web/.env.production.example
+++ b/apps/web/.env.production.example
@@ -51,9 +51,11 @@ INGEST_PER_USER_CONCURRENCY=2
 # so they MUST be URLs the user's browser can reach (public domain or LAN IP).
 
 # LangGraph — NOT in this docker-compose; runs separately via `langgraph up`
-# from apps/agent. Point this at wherever it actually lives in prod.
-LANGGRAPH_API_URL=https://agent.yourcompany.com
-NEXT_PUBLIC_LANGGRAPH_API_URL=https://agent.yourcompany.com
+# from apps/agent (default port 8123, the upstream LangGraph CLI default).
+# Point this at wherever it actually lives in prod — typically a reverse
+# proxy fronting :8123, or the LAN host:port directly.
+LANGGRAPH_API_URL=https://agent.yourcompany.com:8123
+NEXT_PUBLIC_LANGGRAPH_API_URL=https://agent.yourcompany.com:8123
 
 # Workflows API — IS in the prod profile (service `workflows-api`).
 # Server-side: docker service hostname.


### PR DESCRIPTION
Two threads, bundled because they touch the same surface and the second fix needs the first to land cleanly:

* Port convention: split PORT into DEV_PORT (2024) and UP_PORT (8123) to match the upstream LangGraph CLI defaults so `make dev` and `make up` can run side-by-side without colliding. Daily dev keeps `:2024` (so apps/web's LANGGRAPH_API_URL default still works); `make up` and the prod env example now use `:8123`. Add a `make up-recreate` target wrapping `langgraph up --recreate` — the docs' recommended pre-deploy step, and the right tool when a previous compose run leaves stale postgres/redis containers around (yesterday's "server misbehaving" recurrence).

* Checkpoint DB: restore the CHECKPOINT_DB_URL → `--postgres-uri` wiring that 5757301 dropped. Without it, `langgraph up`'s auto-managed postgres sibling races apps/web's compose for host port 5433 and fails to bind. Threaded through up / up-recreate / up-fresh; unset by default so hosts not running web's compose keep the CLI-managed sibling. Override file re-adds `extra_hosts: host.docker.internal: host-gateway` (Linux needs it for the URI to resolve) and exempts host.docker.internal from NO_PROXY so checkpoint traffic doesn't get routed through corp HTTP proxy.

* DOCS: agent README documents the workflow (port table + 5433 conflict recipe with CREATE DATABASE step). agent .env.example shows the CHECKPOINT_DB_URL value to use; .env.production.example documents it as a recommended prod setting. apps/web/.env.production.example bumps LANGGRAPH_API_URL placeholders to :8123 to match the new upstream-aligned port.