### PR TITLE
fix(web): tour bubble waits for route + setup before rendering

### DIFF
--- a/apps/web/components/guides/active-guide-player.tsx
+++ b/apps/web/components/guides/active-guide-player.tsx
@@ -66,6 +66,17 @@ export function ActiveGuidePlayer() {
     closeGuide();
   }, [guide, runTriggers, closeGuide]);
 
+  // Gate render until setup finishes + pathname matches the step's route, so
+  // the GuideLayer doesn't flash with the new step's content while still on
+  // the previous page.
+  const [setupSettled, setSetupSettled] = useState(false);
+  const [lastSettledKey, setLastSettledKey] = useState<string>(`${activeGuideId}:${stepIndex}`);
+  const settleKey = `${activeGuideId}:${stepIndex}`;
+  if (settleKey !== lastSettledKey) {
+    setLastSettledKey(settleKey);
+    setSetupSettled(false);
+  }
+
   // Setup: navigate, run trigger, (optionally) wait for selector.
   // Runs whenever we move to a new step.
   const setupSeq = useRef(0);
@@ -103,6 +114,10 @@ export function ActiveGuidePlayer() {
         if (el instanceof HTMLElement) {
           el.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
         }
+      }
+      // 5. Setup done — unblock the render gate.
+      if (!cancelled && seq === setupSeq.current) {
+        setSetupSettled(true);
       }
     }
     setup();
@@ -195,6 +210,12 @@ export function ActiveGuidePlayer() {
   }, [guide, step]);
 
   if (!guide || !step) return null;
+
+  // Hold the GuideLayer until the route + setup has flushed so the bubble
+  // never previews the next step on the previous page.
+  const stripped = pathname?.replace(/^\/(en|zh)(?=\/|$)/, "") || "/";
+  const onRoute = !step.route || stripped === step.route;
+  if (!onRoute || !setupSettled) return null;
 
   const stripPrefix = (k: string) => k.replace(/^guides\./, "");
 

--- a/apps/web/components/guides/first-run-tour.tsx
+++ b/apps/web/components/guides/first-run-tour.tsx
@@ -29,6 +29,16 @@ export function FirstRunTour() {
   // first-run step can land on the wrong page (e.g. add-sources pointing at
   // [data-guide="add-source-trigger"] which only exists inside a notebook
   // workspace, not on /deepdive).
+  // Gate the Spotlight render on setup completion + pathname match so the
+  // bubble never appears with new content while the previous page is still on
+  // screen. Reset to false on step change via setState-during-render.
+  const [setupSettled, setSetupSettled] = useState(false);
+  const [lastSettledStep, setLastSettledStep] = useState(tour.stepIndex);
+  if (tour.stepIndex !== lastSettledStep) {
+    setLastSettledStep(tour.stepIndex);
+    setSetupSettled(false);
+  }
+
   const setupSeq = useRef(0);
   useEffect(() => {
     if (tour.stage !== "running") return;
@@ -69,6 +79,10 @@ export function FirstRunTour() {
           el.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
         }
       }
+      // 5. Setup done — unblock the render gate.
+      if (!cancelled && seq === setupSeq.current) {
+        setSetupSettled(true);
+      }
     }
     run();
     return () => {
@@ -107,29 +121,35 @@ export function FirstRunTour() {
           </div>
         </div>
       ) : null}
-      {tour.stage === "running" && steps.length > 0 ? (
-        (() => {
-          const current = steps[tour.stepIndex] ?? steps[steps.length - 1];
-          const stripPrefix = (k: string) => k.replace(/^guides\./, "");
-          return (
-            <Spotlight
-              selector={current.selector}
-              placement={current.placement}
-              title={tGuides(stripPrefix(current.titleKey))}
-              body={tGuides(stripPrefix(current.bodyKey))}
-              stepIndex={tour.stepIndex}
-              totalSteps={steps.length}
-              onNext={() => (tour.stepIndex === steps.length - 1 ? tour.finish() : tour.next())}
-              onPrev={tour.stepIndex > 0 ? tour.prev : undefined}
-              onClose={handleSkip}
-              nextLabel={t("next")}
-              prevLabel={t("prev")}
-              closeLabel={t("close")}
-              finishLabel={t("finish")}
-            />
-          );
-        })()
-      ) : null}
+      {tour.stage === "running" && steps.length > 0
+        ? (() => {
+            const current = steps[tour.stepIndex] ?? steps[steps.length - 1];
+            // Hold the Spotlight until both the route AND the setup sequence
+            // have flushed — otherwise the next step's bubble paints on top of
+            // the previous page for one frame.
+            const stripped = pathname?.replace(/^\/(en|zh)(?=\/|$)/, "") || "/";
+            const onRoute = !current.route || stripped === current.route;
+            if (!onRoute || !setupSettled) return null;
+            const stripPrefix = (k: string) => k.replace(/^guides\./, "");
+            return (
+              <Spotlight
+                selector={current.selector}
+                placement={current.placement}
+                title={tGuides(stripPrefix(current.titleKey))}
+                body={tGuides(stripPrefix(current.bodyKey))}
+                stepIndex={tour.stepIndex}
+                totalSteps={steps.length}
+                onNext={() => (tour.stepIndex === steps.length - 1 ? tour.finish() : tour.next())}
+                onPrev={tour.stepIndex > 0 ? tour.prev : undefined}
+                onClose={handleSkip}
+                nextLabel={t("next")}
+                prevLabel={t("prev")}
+                closeLabel={t("close")}
+                finishLabel={t("finish")}
+              />
+            );
+          })()
+        : null}
       {showSkipBanner ? (
         <div className="fixed bottom-20 left-1/2 z-40 -translate-x-1/2 rounded-lg border border-border bg-background px-4 py-2 text-xs shadow-lg">
           {t("skipToast")}


### PR DESCRIPTION
Both players (FirstRunTour and ActiveGuidePlayer) used to render the next step's Spotlight / GuideLayer in the same React commit that bumped stepIndex — but the route navigation, trigger actions, and waitForSelector all run asynchronously after that. Result: the new bubble paints on top of the previous page for one frame before the page swaps in.

Each player now tracks setupSettled (reset to false on step change via setState-during-render, flipped true at the end of the setup sequence) and also re-checks the locale-stripped pathname against step.route before rendering. The overlay only mounts once both gates clear, keeping the bubble in lockstep with the underlying page transition.