### PR TITLE
feat(llm): route every BYOK call through Python — apps/web stops call…

### DIFF
--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = [
     # Workflow server (FastAPI surface)
     "fastapi>=0.109",
     "uvicorn[standard]>=0.27",
+    # LLM gateway — apps/web (Node) cannot reach LLM providers from inside
+    # the corporate network, so it calls back here. LiteLLM normalizes the
+    # 100+ provider chat-completions API and handles BYOK key + base URL.
+    "litellm>=1.50",
     # Daily-digest ARQ worker queue
     "arq>=0.25",
     # Matcher workflow (Excel ingestion + ranking)

--- a/apps/agent/server/app.py
+++ b/apps/agent/server/app.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI, HTTPException, Request
 from arq import create_pool
 from arq.connections import ArqRedis
 
+from server.routes.llm_gateway import router as llm_gateway_router
 from server.routes.matcher_jobs import router as matcher_jobs_router
 from workflows.daily_digest import GenerateSectionRequest, generate_section as run_generate_section
 from workflows.digest_worker import WorkerSettings
@@ -35,6 +36,9 @@ async def _lifespan(app: FastAPI):
 app = FastAPI(title="SparkFlow Workflows", version="0.1.0", lifespan=_lifespan)
 
 app.include_router(matcher_jobs_router, prefix="/v1/workflows/matcher")
+# LLM gateway — Node BYOK chat completions + model-list passthrough.
+# Mounted at root because the routes already include /v1/llm/* prefixes.
+app.include_router(llm_gateway_router)
 
 
 @app.get("/v1/healthz")

--- a/apps/agent/server/routes/llm_gateway.py
+++ b/apps/agent/server/routes/llm_gateway.py
@@ -1,0 +1,299 @@
+"""LLM gateway — Node-side BYOK chat completions and model-list passthrough.
+
+Why this exists: apps/web runs in an environment whose outbound TLS to
+LLM providers (api.openai.com, api.deepseek.com, generativelanguage…)
+either goes through a TLS-intercepting corporate proxy or is blocked
+outright. Python on the same host already has working httpx + CA
+trust, so we centralize every BYOK upstream call here.
+
+Endpoints:
+  POST /v1/llm/chat/completions   OpenAI-compatible passthrough
+  POST /v1/llm/models              upstream /v1/models proxy
+
+Both require a shared internal token in the `X-Internal-Token` header
+that matches INTERNAL_CALLBACK_TOKEN. The BYOK key + base URL travel
+in the request body so they're never logged or cached at the proxy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# --- shared helpers -----------------------------------------------------
+
+NON_CHAT_MODEL_SUBSTRINGS = (
+    "embedding",
+    "tts",
+    "whisper",
+    "dall-e",
+    "audio",
+    "image",
+    "realtime",
+    "imagen",
+    "veo",
+    "cogview",
+    "cogvideo",
+    "moderation",
+    "rerank",
+)
+
+
+def _redact(text: str, secret: str) -> str:
+    if not secret or len(secret) < 4:
+        return text
+    return text.replace(secret, "***")
+
+
+def _verify_token(token: str | None) -> None:
+    expected = os.getenv("INTERNAL_CALLBACK_TOKEN", "")
+    if not expected or not token or token != expected:
+        # Generic 401, never explains which side mismatched.
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def _is_chat_model(model_id: str) -> bool:
+    lower = model_id.lower()
+    return not any(s in lower for s in NON_CHAT_MODEL_SUBSTRINGS)
+
+
+# --- /v1/llm/models -----------------------------------------------------
+
+
+class ListModelsRequest(BaseModel):
+    providerId: str
+    apiKey: str
+    baseUrl: str | None = None
+
+
+class ListModelsResponse(BaseModel):
+    providerId: str
+    models: list[str]
+
+
+# Built-in provider baseURLs. Mirrors apps/web/lib/types/providers.ts so the
+# Node side can pass providerId only and let Python resolve the URL.
+_BUILTIN_BASE_URLS: dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+    "gemini": "https://generativelanguage.googleapis.com/v1beta/openai",
+    "deepseek": "https://api.deepseek.com/v1",
+    "glm": "https://open.bigmodel.cn/api/paas/v4",
+    "minimax": "https://api.minimax.chat/v1",
+    "kimi": "https://api.moonshot.cn/v1",
+}
+
+# Minimax doesn't expose /v1/models — return a hand-curated list instead.
+# Keep in sync with apps/web/lib/types/providers.ts:fallbackModels.
+_MINIMAX_FALLBACK = [
+    "MiniMax-M2.7",
+    "MiniMax-M2.7-highspeed",
+    "MiniMax-M2.5",
+    "MiniMax-M2.5-highspeed",
+    "MiniMax-M2.1",
+]
+
+_PRIVATE_HOST_RE = re.compile(
+    r"^(localhost|0\.0\.0\.0|127\.|10\.|192\.168\.|169\.254\.|172\.(1[6-9]|2\d|3[0-1])\.|::1|fc|fd|fe80)",
+    re.IGNORECASE,
+)
+
+
+def _assert_safe_url(raw: str) -> str:
+    """SSRF guard — reject loopback / RFC1918 / link-local."""
+    parsed = httpx.URL(raw)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail=f"Unsupported protocol {parsed.scheme}")
+    host = (parsed.host or "").lower()
+    if host.endswith(".local") or host.endswith(".internal") or _PRIVATE_HOST_RE.match(host):
+        raise HTTPException(status_code=400, detail=f"Private host '{host}' is not allowed")
+    return str(parsed)
+
+
+@router.post("/v1/llm/models", response_model=ListModelsResponse)
+async def list_models(
+    body: ListModelsRequest,
+    x_internal_token: str | None = Header(default=None, alias="X-Internal-Token"),
+) -> ListModelsResponse:
+    _verify_token(x_internal_token)
+
+    # Minimax has no /v1/models endpoint per official docs.
+    if body.providerId == "minimax":
+        return ListModelsResponse(
+            providerId=body.providerId,
+            models=[m for m in _MINIMAX_FALLBACK if _is_chat_model(m)],
+        )
+
+    base_url = body.baseUrl or _BUILTIN_BASE_URLS.get(body.providerId)
+    if not base_url:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown provider '{body.providerId}' and no baseUrl provided",
+        )
+    base_url = _assert_safe_url(base_url).rstrip("/")
+    url = f"{base_url}/models"
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            res = await client.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {body.apiKey}",
+                    "Accept": "application/json",
+                },
+            )
+    except httpx.TimeoutException:
+        raise HTTPException(
+            status_code=504,
+            detail={"code": "TIMEOUT", "providerId": body.providerId, "message": "Provider /models timed out"},
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "NETWORK_ERROR",
+                "providerId": body.providerId,
+                "message": _redact(str(exc), body.apiKey),
+            },
+        )
+
+    if res.status_code in (401, 403):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "INVALID_KEY",
+                "providerId": body.providerId,
+                "upstreamStatus": res.status_code,
+                "message": f"Provider rejected the API key (HTTP {res.status_code})",
+            },
+        )
+    if res.status_code >= 400:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "BAD_RESPONSE",
+                "providerId": body.providerId,
+                "upstreamStatus": res.status_code,
+                "message": _redact(res.text, body.apiKey)[:500],
+            },
+        )
+
+    try:
+        payload: dict[str, Any] = res.json()
+    except ValueError:
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "BAD_RESPONSE", "providerId": body.providerId, "message": "Non-JSON response"},
+        )
+
+    raw_models = payload.get("data") or []
+    if not isinstance(raw_models, list):
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "BAD_RESPONSE", "providerId": body.providerId, "message": "Missing data[]"},
+        )
+
+    ids = sorted(
+        m["id"]
+        for m in raw_models
+        if isinstance(m, dict) and isinstance(m.get("id"), str) and m["id"]
+    )
+    return ListModelsResponse(
+        providerId=body.providerId,
+        models=[i for i in ids if _is_chat_model(i)],
+    )
+
+
+# --- /v1/llm/chat/completions ------------------------------------------
+
+
+@router.post("/v1/llm/chat/completions")
+async def chat_completions(
+    body: dict[str, Any],
+    x_internal_token: str | None = Header(default=None, alias="X-Internal-Token"),
+    x_byok_provider: str | None = Header(default=None, alias="X-Byok-Provider"),
+    x_byok_key: str | None = Header(default=None, alias="X-Byok-Key"),
+    x_byok_base_url: str | None = Header(default=None, alias="X-Byok-Base-Url"),
+) -> dict[str, Any]:
+    """OpenAI-compatible chat completions, forwarded via LiteLLM.
+
+    The Node caller passes its BYOK info in headers (so request bodies
+    can be logged for debugging without leaking keys). The body itself
+    is the standard OpenAI chat/completions shape — `model`, `messages`,
+    `temperature`, `max_tokens`, `tools`, etc.
+    """
+    _verify_token(x_internal_token)
+    if not x_byok_provider or not x_byok_key:
+        raise HTTPException(
+            status_code=400,
+            detail="Missing X-Byok-Provider / X-Byok-Key headers",
+        )
+    model = body.get("model")
+    if not isinstance(model, str) or not model:
+        raise HTTPException(status_code=400, detail="Body must include `model`")
+
+    if x_byok_base_url:
+        _assert_safe_url(x_byok_base_url)
+
+    # Lazy import — litellm has heavy module-level init we don't want to
+    # pay for in cold-start of unrelated routes.
+    import litellm  # type: ignore
+
+    # LiteLLM uses "{provider}/{model}" routing; the providers we support
+    # are all OpenAI-compatible, so we go through the openai adapter and
+    # let `api_base` / `api_key` steer the request to the right host.
+    # The provider id in `model` only matters for cost-tracking, which
+    # we don't use server-side.
+    litellm_model = f"openai/{model}"
+
+    try:
+        response = await litellm.acompletion(
+            model=litellm_model,
+            api_key=x_byok_key,
+            api_base=x_byok_base_url,
+            **{k: v for k, v in body.items() if k != "model"},
+        )
+    except litellm.AuthenticationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "INVALID_KEY",
+                "providerId": x_byok_provider,
+                "message": _redact(str(exc), x_byok_key),
+            },
+        )
+    except litellm.Timeout as exc:
+        raise HTTPException(
+            status_code=504,
+            detail={
+                "code": "TIMEOUT",
+                "providerId": x_byok_provider,
+                "message": _redact(str(exc), x_byok_key),
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — broad on purpose
+        logger.exception("[llm-gateway] chat completion failed")
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "UPSTREAM_ERROR",
+                "providerId": x_byok_provider,
+                "message": _redact(str(exc), x_byok_key),
+            },
+        )
+
+    # `response` is a litellm ModelResponse. Its .model_dump() gives the
+    # OpenAI-shaped JSON the Node client (using OpenAI SDK) expects.
+    if hasattr(response, "model_dump"):
+        return response.model_dump()
+    return response  # type: ignore[return-value]

--- a/apps/web/lib/providers/list-models.ts
+++ b/apps/web/lib/providers/list-models.ts
@@ -1,10 +1,16 @@
 import {
   PROVIDER_MAP,
-  NON_CHAT_MODEL_SUBSTRINGS,
   CUSTOM_PROVIDER_PREFIX,
 } from "@/lib/types/providers";
 
-const FETCH_TIMEOUT_MS = 10_000;
+/**
+ * Apps/web (Node) cannot reach LLM providers directly from the
+ * corporate network — outbound TLS is intercepted or blocked. All
+ * BYOK calls go through apps/agent's `/v1/llm/*` gateway, which uses
+ * Python's working httpx + CA trust chain.
+ */
+
+const FETCH_TIMEOUT_MS = 12_000;
 
 export type FetchModelsErrorCode =
   | "INVALID_KEY"
@@ -12,7 +18,8 @@ export type FetchModelsErrorCode =
   | "TIMEOUT"
   | "NETWORK_ERROR"
   | "BAD_RESPONSE"
-  | "PROVIDER_UNKNOWN";
+  | "PROVIDER_UNKNOWN"
+  | "GATEWAY_NOT_CONFIGURED";
 
 export class FetchModelsError extends Error {
   public readonly code: FetchModelsErrorCode;
@@ -33,12 +40,35 @@ export class FetchModelsError extends Error {
 }
 
 /**
- * Reject baseUrls that point inside the docker network or back at the
- * server itself. Defends against SSRF via a user-supplied custom
- * endpoint. Called from both the POST /api/settings validation path
- * AND immediately before the fetch in fetchProviderModels (defense in
- * depth — the URL might bypass zod if a built-in provider's baseUrl
- * is later overridden).
+ * Resolves the URL of the apps/agent LLM gateway. Defaults to
+ * localhost:2027 (host-side dev), overridden in production via
+ * WORKFLOWS_API_URL or the docker-compose service hostname.
+ */
+function gatewayBase(): string {
+  return (
+    process.env.WORKFLOWS_API_URL ||
+    process.env.NEXT_PUBLIC_WORKFLOWS_API_URL ||
+    "http://localhost:2027"
+  ).replace(/\/$/, "");
+}
+
+function internalToken(): string {
+  const t = process.env.INTERNAL_CALLBACK_TOKEN;
+  if (!t) {
+    throw new FetchModelsError(
+      "GATEWAY_NOT_CONFIGURED",
+      "_",
+      "INTERNAL_CALLBACK_TOKEN is not set; the Node side cannot authenticate to the LLM gateway",
+    );
+  }
+  return t;
+}
+
+/**
+ * Lightweight SSRF check on the user-supplied custom baseUrl. The
+ * Python gateway re-checks before issuing the upstream call (defense
+ * in depth) — this version just gives the user fast feedback when
+ * they typo a localhost URL into the settings form.
  */
 export function assertSafeUrl(raw: string, providerId: string): URL {
   let parsed: URL;
@@ -83,27 +113,13 @@ export function assertSafeUrl(raw: string, providerId: string): URL {
   return parsed;
 }
 
-function sanitizeError(err: unknown, apiKey: string): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  return apiKey ? raw.replaceAll(apiKey, "***") : raw;
-}
-
-export function isChatModel(id: string): boolean {
-  const lower = id.toLowerCase();
-  return !NON_CHAT_MODEL_SUBSTRINGS.some((s) => lower.includes(s));
-}
-
-interface ProviderListResponse {
-  data?: Array<{ id?: string }>;
-}
-
 /**
- * GET ${baseUrl}${modelsPath} with Bearer auth. Returns the chat-model
- * IDs only. Built-in providers resolve `baseUrl` from PROVIDER_MAP;
- * `custom-*` providers must pass `baseUrl` explicitly.
+ * Fetch the chat-capable model id list for `providerId`. Built-in
+ * providers resolve their baseUrl via PROVIDER_MAP; custom providers
+ * (id `custom` or `custom-…`) require an explicit `baseUrl`.
  *
- * Throws FetchModelsError on any failure — never leaks the apiKey
- * into messages, never returns a partial result.
+ * Implementation: POST to apps/agent's /v1/llm/models gateway. The
+ * Python side handles the actual upstream call + response filtering.
  */
 export async function fetchProviderModels(
   providerId: string,
@@ -111,37 +127,20 @@ export async function fetchProviderModels(
   baseUrl?: string,
   signal?: AbortSignal,
 ): Promise<string[]> {
-  // Providers without a /v1/models endpoint (e.g. Minimax) get a
-  // hardcoded fallback. We still validate the apiKey though — see
-  // validateApiKey() below. This branch is purely about returning the
-  // model list for the dropdown.
-  const cfg = PROVIDER_MAP.get(providerId);
-  if (cfg?.noModelsEndpoint && cfg.fallbackModels) {
-    return cfg.fallbackModels.filter(isChatModel);
-  }
-
-  // Resolve the actual URL. Custom providers MUST supply baseUrl;
-  // built-ins fall back to PROVIDER_MAP.
+  // Built-in providers don't carry baseUrl from the caller — fill it
+  // from PROVIDER_MAP so the gateway can route.
   let resolvedBaseUrl = baseUrl;
   if (!resolvedBaseUrl) {
     const provider = PROVIDER_MAP.get(providerId);
-    if (!provider?.baseUrl) {
+    if (!provider) {
       throw new FetchModelsError(
         "PROVIDER_UNKNOWN",
         providerId,
-        `Unknown provider "${providerId}" or missing baseUrl`,
+        `Unknown provider "${providerId}"`,
       );
     }
     resolvedBaseUrl = provider.baseUrl;
   }
-  // SSRF guard runs on every fetch, even for built-ins, so a future
-  // misconfigured PROVIDERS entry can't accidentally bypass.
-  const safe = assertSafeUrl(resolvedBaseUrl, providerId);
-  const provider = PROVIDER_MAP.get(providerId);
-  const path = provider?.modelsPath ?? "/models";
-  // strip trailing slash from base, leading slash from path consistency
-  const base = safe.toString().replace(/\/$/, "");
-  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
 
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
@@ -152,11 +151,17 @@ export async function fetchProviderModels(
 
   let res: Response;
   try {
-    res = await fetch(url, {
+    res = await fetch(`${gatewayBase()}/v1/llm/models`, {
+      method: "POST",
       headers: {
-        Authorization: `Bearer ${apiKey}`,
-        Accept: "application/json",
+        "Content-Type": "application/json",
+        "X-Internal-Token": internalToken(),
       },
+      body: JSON.stringify({
+        providerId,
+        apiKey,
+        ...(resolvedBaseUrl ? { baseUrl: resolvedBaseUrl } : {}),
+      }),
       signal: ctrl.signal,
       cache: "no-store",
     });
@@ -165,68 +170,58 @@ export async function fetchProviderModels(
       throw new FetchModelsError(
         "TIMEOUT",
         providerId,
-        `Request to ${providerId} /models timed out after ${FETCH_TIMEOUT_MS}ms`,
+        `LLM gateway timed out after ${FETCH_TIMEOUT_MS}ms`,
       );
     }
+    if (err instanceof FetchModelsError) throw err;
     throw new FetchModelsError(
       "NETWORK_ERROR",
       providerId,
-      sanitizeError(err, apiKey),
+      (err as Error)?.message ?? "fetch failed",
     );
   } finally {
     clearTimeout(timer);
   }
 
-  if (!res.ok) {
-    if (res.status === 401 || res.status === 403) {
+  if (res.ok) {
+    const body = (await res.json()) as { models?: string[] };
+    if (!Array.isArray(body.models)) {
       throw new FetchModelsError(
-        "INVALID_KEY",
+        "BAD_RESPONSE",
         providerId,
-        `Provider rejected the API key (HTTP ${res.status})`,
-        res.status,
+        "Gateway response missing models[]",
       );
     }
-    throw new FetchModelsError(
-      "BAD_RESPONSE",
-      providerId,
-      `Provider returned HTTP ${res.status}`,
-      res.status,
-    );
+    return body.models;
   }
 
-  let body: ProviderListResponse;
+  // FastAPI puts our structured detail in `body.detail`.
+  let detail: unknown;
   try {
-    body = (await res.json()) as ProviderListResponse;
-  } catch (err) {
+    detail = (await res.json())?.detail;
+  } catch {
+    detail = undefined;
+  }
+  if (detail && typeof detail === "object") {
+    const d = detail as {
+      code?: FetchModelsErrorCode;
+      message?: string;
+      upstreamStatus?: number;
+    };
     throw new FetchModelsError(
-      "BAD_RESPONSE",
+      d.code ?? "BAD_RESPONSE",
       providerId,
-      sanitizeError(err, apiKey),
+      d.message ?? `Gateway returned HTTP ${res.status}`,
+      d.upstreamStatus,
     );
   }
-
-  if (!Array.isArray(body.data)) {
-    throw new FetchModelsError(
-      "BAD_RESPONSE",
-      providerId,
-      "Response missing data[] array",
-    );
-  }
-
-  const ids = body.data
-    .map((m) => m.id)
-    .filter((id): id is string => typeof id === "string" && id.length > 0)
-    .filter(isChatModel)
-    .sort();
-
-  return ids;
+  throw new FetchModelsError(
+    "BAD_RESPONSE",
+    providerId,
+    `Gateway returned HTTP ${res.status}`,
+  );
 }
 
-/**
- * True when this providerId belongs to a user-defined custom endpoint
- * (id is `custom` literal or `custom-…`). Built-in providers always
- * have an entry in PROVIDER_MAP.
- */
 export function isCustomProviderId(providerId: string): boolean {
   return providerId === "custom" || providerId.startsWith(CUSTOM_PROVIDER_PREFIX);
 }

--- a/apps/web/lib/services/graph-service.ts
+++ b/apps/web/lib/services/graph-service.ts
@@ -9,6 +9,12 @@ import prisma from "@/lib/prisma";
 // (including admins) configure their own keys via Settings. If the user
 // hasn't picked a wiki model OR hasn't set an API key for that provider,
 // this throws — the ingest pipeline surfaces the error to the client.
+//
+// The returned `client` is an OpenAI SDK instance pointed at apps/agent's
+// `/v1/llm/chat/completions` gateway, NOT directly at the LLM provider.
+// apps/web (Node) cannot reach LLM providers from the corporate network;
+// Python on the same host can. The gateway forwards via LiteLLM. BYOK
+// info is passed in custom headers per OpenAI SDK's `defaultHeaders`.
 async function resolveWikiClient(userId: string) {
   const { default: OpenAI } = await import("openai");
   const { resolveApiKey } = await import("@/lib/services/api-key-resolver");
@@ -24,22 +30,37 @@ async function resolveWikiClient(userId: string) {
     );
   }
 
-  // resolveApiKey throws if the user hasn't configured a BYOK key for
-  // this provider; the error message points them at /settings.
   const resolved = await resolveApiKey(userId, settings.wikiModelProvider);
 
-  // Explicit timeout/retries because the SDK default is 10 minutes — too
-  // long for an interactive ingest pipeline. Tunable via env so corporate
-  // networks with TLS-intercepting proxies can dial up if needed.
+  const gatewayBase = (
+    process.env.WORKFLOWS_API_URL || "http://localhost:2027"
+  ).replace(/\/$/, "");
+  const internalToken = process.env.INTERNAL_CALLBACK_TOKEN;
+  if (!internalToken) {
+    throw new Error(
+      "INTERNAL_CALLBACK_TOKEN is not configured — the LLM gateway will reject requests",
+    );
+  }
+
+  // Explicit timeout/retries because the SDK default is 10 minutes —
+  // too long for an interactive ingest pipeline. Tunable via env.
   const timeoutMs = Number(process.env.WIKI_LLM_TIMEOUT_MS ?? 180_000);
   const maxRetries = Number(process.env.WIKI_LLM_MAX_RETRIES ?? 2);
 
   return {
     client: new OpenAI({
-      apiKey: resolved.apiKey,
-      baseURL: resolved.baseUrl,
+      baseURL: `${gatewayBase}/v1/llm`,
+      // The gateway ignores Authorization; the real BYOK key is in
+      // X-Byok-Key. Passing a placeholder keeps the OpenAI SDK happy.
+      apiKey: "passthrough",
       timeout: timeoutMs,
       maxRetries,
+      defaultHeaders: {
+        "X-Internal-Token": internalToken,
+        "X-Byok-Provider": settings.wikiModelProvider,
+        "X-Byok-Key": resolved.apiKey,
+        ...(resolved.baseUrl ? { "X-Byok-Base-Url": resolved.baseUrl } : {}),
+      },
     }),
     model: settings.wikiModelName,
   };


### PR DESCRIPTION
…ing LLMs directly

apps/web (Node) cannot reach LLM providers from the corporate network: outbound TLS to api.openai.com / api.deepseek.com / etc. is intercepted or blocked, and patching Node's TLS trust chain to match Python's ended up a rabbit hole (DeepSeek SSL handshake failed even after CA bundle install). Python on the same host has working httpx
+ CA trust because it was set up that way for digest-worker / langgraph-api / search workflow long ago. Centralize every BYOK call through there.

* apps/agent/server/routes/llm_gateway.py (NEW) — two endpoints:
  - POST /v1/llm/models   : upstream /v1/models passthrough; SSRF
    guard, redact apiKey from any error message, structured error
    detail (code/providerId/upstreamStatus). Minimax short-circuits
    to its hand-curated fallback (no /v1/models endpoint).
  - POST /v1/llm/chat/completions : OpenAI-compatible body, BYOK
    info in headers (X-Byok-Provider / X-Byok-Key / X-Byok-Base-Url).
    Forwards via litellm.acompletion(); errors translated to the
    same structured detail shape. Lazy-imports litellm so the rest
    of the FastAPI app stays cold-start clean.
  Both require X-Internal-Token == INTERNAL_CALLBACK_TOKEN; rejects
  with 401 otherwise. Mounted at root in server/app.py — paths
  already include /v1/llm prefixes.

* apps/agent/pyproject.toml — add litellm>=1.50 runtime dep.

* apps/web/lib/providers/list-models.ts — rewrite. Drops the direct fetch to provider /v1/models; instead POSTs to the gateway with {providerId, apiKey, baseUrl?} + X-Internal-Token. Keeps the pre-existing FetchModelsError shape so /api/models and the settings POST validation path don't change. SSRF guard kept on the Node side too (defense in depth + faster user feedback for obviously bad custom URLs).

* apps/web/lib/services/graph-service.ts — wiki extraction stops pointing the OpenAI client at the user's BYOK provider directly. baseURL now points at ${WORKFLOWS_API_URL}/v1/llm; BYOK info goes in defaultHeaders (X-Internal-Token + X-Byok-{Provider,Key,Base-Url}), apiKey field is a passthrough placeholder. All three call sites in this file (extractGraph, summarizePage, etc.) inherit the new routing because they all go through resolveWikiClient().

Net effect: the only Node→LLM direct call site in the repo is gone; every wiki ingest LLM hop and every settings model-list hop flows through Python. The wiki-ingest "Request timed out" loop should stop as soon as `make serve` is running (or the prod workflows-api container is up).

Verified: `npx tsc --noEmit` clean; agent test suite still loads the FastAPI app with the new routes registered (matcher_workflow errors are unrelated — they need a live local Redis).