### PR TITLE
fix(docker): drop COPY of deleted hermes/ and config/ from workflows-…

### DIFF
--- a/apps/langgraph/Dockerfile.workflows-api
+++ b/apps/langgraph/Dockerfile.workflows-api
@@ -40,12 +40,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Copy only the source the workflows API touches transitively. The
 # `workflows` and `server` packages aren't in pyproject.toml's hatch
-# packages list, so they must be copied raw.
+# packages list, so they must be copied raw. `tools` is imported by
+# workflows.search (tools.web). `prompts` is read by workflows that
+# need system-prompt fragments (currently none — kept for forward
+# compat with future workflow LLM calls).
 COPY workflows ./workflows
 COPY server ./server
 COPY tools ./tools
-COPY hermes ./hermes
-COPY config ./config
 COPY prompts ./prompts
 
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app


### PR DESCRIPTION
…api Dockerfile

Both directories were deleted during the agent refactor (hermes in commit 04aa361, config in commit 8ee3c7d) but the Dockerfile wasn't updated. Build failed at COPY hermes ./hermes with 'not found'.

The workflows-api process doesn't import either:
- workflows/, server/, tools/ are the only packages with code that matters at runtime for HTTP routes
- agents/ and prompt_builder.py are NOT imported by the workflows-api (those run in the langgraph-api / web process via copilotkit)
- hermes/ and config/ are gone entirely

Just dropping the two stale COPY lines.