### PR TITLE
chore(docker): single ca-certificates.crt at repo root via additional…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,12 +61,12 @@ coverage/
 # Prisma backups
 *.prisma.bak
 
-# Corporate CA bundle (per-host, mounted into docker images at build time;
-# empty placeholder ok). Same-name files exist in apps/web/ and apps/langgraph/
-# because each Dockerfile COPYs from its own build context.
+# Corporate CA bundle (per-host). Single file at repo root; injected into
+# all Dockerfiles via Compose's `additional_contexts: { certs: ./ }` and
+# `COPY --from=certs ca-certificates.crt ...`. Empty placeholder OK on
+# networks that don't need a corp CA — Dockerfiles `if [ -s ... ]` skip
+# the install step.
 ca-certificates.crt
-apps/web/ca-certificates.crt
-apps/langgraph/ca-certificates.crt
 
 # SearXNG runtime data (created by docker compose; per-host)
 searxng/

--- a/apps/langgraph/Dockerfile.worker
+++ b/apps/langgraph/Dockerfile.worker
@@ -16,7 +16,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 # File MUST exist; empty = no-op for open networks.
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-COPY ca-certificates.crt /tmp/corporate-ca.crt
+COPY --from=certs ca-certificates.crt /tmp/corporate-ca.crt
 RUN if [ -s /tmp/corporate-ca.crt ]; then \
       cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
       update-ca-certificates; \

--- a/apps/langgraph/Dockerfile.workflows-api
+++ b/apps/langgraph/Dockerfile.workflows-api
@@ -19,7 +19,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 # install no-ops. File MUST exist (gitignored — see apps/langgraph/.gitignore).
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-COPY ca-certificates.crt /tmp/corporate-ca.crt
+COPY --from=certs ca-certificates.crt /tmp/corporate-ca.crt
 RUN if [ -s /tmp/corporate-ca.crt ]; then \
       cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
       update-ca-certificates; \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -4,7 +4,7 @@
 # empty is fine on open networks).
 FROM node:24 AS base
 WORKDIR /app
-COPY ca-certificates.crt /tmp/corporate-ca.crt
+COPY --from=certs ca-certificates.crt /tmp/corporate-ca.crt
 RUN if [ -s /tmp/corporate-ca.crt ]; then \
       cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
       update-ca-certificates; \

--- a/apps/web/Dockerfile.worker
+++ b/apps/web/Dockerfile.worker
@@ -11,7 +11,7 @@ ENV NODE_ENV=production
 # gitignored — populate with your CA on networks that need it, otherwise
 # leave empty. Done in `base` so every derived stage (deps build AND
 # runtime) trusts the CA, not just the install step.
-COPY ca-certificates.crt /tmp/corporate-ca.crt
+COPY --from=certs ca-certificates.crt /tmp/corporate-ca.crt
 RUN if [ -s /tmp/corporate-ca.crt ]; then \
       cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
       update-ca-certificates; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
     build:
       context: ./apps/web
       dockerfile: Dockerfile.worker
+      additional_contexts:
+        certs: ./
     container_name: sparkflow-ingest-worker
     command: ["npm", "run", "worker:ingest"]
     env_file: ./apps/web/.env
@@ -84,6 +86,8 @@ services:
     build:
       context: ./apps/langgraph
       dockerfile: Dockerfile.worker
+      additional_contexts:
+        certs: ./
     container_name: sparkflow-digest-worker
     command: ["arq", "workflows.digest_worker.WorkerSettings"]
     env_file: ./apps/langgraph/.env
@@ -112,6 +116,8 @@ services:
     build:
       context: ./apps/langgraph
       dockerfile: Dockerfile.workflows-api
+      additional_contexts:
+        certs: ./
     container_name: sparkflow-workflows-api
     env_file: ./apps/langgraph/.env
     environment:
@@ -141,6 +147,8 @@ services:
       # transitive deps like `effect`). The slim runner stage only carries
       # cherry-picked @prisma/* dirs and breaks at CLI load time.
       target: builder
+      additional_contexts:
+        certs: ./
     container_name: sparkflow-migrate
     command: ["npx", "prisma", "migrate", "deploy"]
     env_file: ./apps/web/.env
@@ -157,6 +165,8 @@ services:
       context: ./apps/web
       dockerfile: Dockerfile
       target: runner
+      additional_contexts:
+        certs: ./
     container_name: sparkflow-web
     env_file: ./apps/web/.env
     environment:


### PR DESCRIPTION
…_contexts

Previously each Dockerfile COPYed ca-certificates.crt from its own build context (apps/web/ for web+ingest-worker+migrate, apps/langgraph/ for workflows-api+digest-worker), so users had to maintain three identical copies. Use Docker Buildx's named build contexts to inject the single root cert into every Dockerfile:

- docker-compose.yml: each of the 5 build blocks gets `additional_contexts: { certs: ./ }` (Compose v2.17+, Buildx 0.13+)
- apps/{web,langgraph}/Dockerfile{,.worker,.workflows-api}: each `COPY ca-certificates.crt /tmp/...` becomes `COPY --from=certs ca-certificates.crt /tmp/...`
- Per-app cert files deleted (only root file remains)
- .gitignore reduced to one entry

Verified: `docker compose --profile prod build --no-cache` builds all 5 images successfully (only ./ca-certificates.crt exists; the per-app files are gone).

Setup is now `touch ca-certificates.crt` (one file) instead of three.