### PR TITLE
feat(docker): containerize apps/semops; add to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,12 +222,17 @@ cd apps/langgraph && make dev
 # Terminal 3 — Workflows FastAPI (port 2027)
 cd apps/langgraph && make serve
 
-# Terminal 4 — Semops (port 2025)
-cd apps/semops && python main.py
+# Semops (port 2025) now runs inside docker compose by default —
+# no separate terminal needed. If you'd rather run it on the host
+# during dev (faster iteration on the LOTUS code):
+#   docker compose stop semops
+#   cd apps/semops && python main.py
+# Then `apps/langgraph/.env` should point SEMOPS_API_URL at host:
+#   SEMOPS_API_URL=http://host.docker.internal:2025
 ```
 
-The wiki-ingest and daily-digest workers run inside docker compose, no
-host process needed.
+The wiki-ingest worker, daily-digest worker, and semops all run inside
+docker compose by default — no extra host processes needed.
 
 5. **Access the application**
 

--- a/apps/semops/.dockerignore
+++ b/apps/semops/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.pytest_cache/
+.ruff_cache/
+.env
+.env.*
+tests/
+*.log

--- a/apps/semops/Dockerfile
+++ b/apps/semops/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.7
+# SemOps service — LOTUS-backed semantic operators (sem_rank, sem_filter, ...)
+# consumed by apps/langgraph/workflows/{matcher,daily_digest,search}.
+#
+# Heavy deps (lotus-ai pulls torch + transformers + faiss-cpu + sentence-transformers).
+# First build is slow; layer caching keeps subsequent rebuilds fast.
+
+# lotus-ai 1.1.x pins numpy==1.26.4 which has no wheel for Python 3.13
+# and its sdist build (mesonpy) fails on 3.13. Pin to 3.12 until lotus-ai
+# bumps its numpy floor.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Optional corporate CA bundle. Same pattern as apps/langgraph/Dockerfile.*:
+# injected via Compose's `additional_contexts: { certs: ./ }` so a single
+# root cert serves every Dockerfile.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=certs ca-certificates.crt /tmp/corporate-ca.crt
+RUN if [ -s /tmp/corporate-ca.crt ]; then \
+      cp /tmp/corporate-ca.crt /usr/local/share/ca-certificates/corporate.crt && \
+      update-ca-certificates; \
+    fi && rm /tmp/corporate-ca.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+# Install Python deps. requirements.txt pins minor floors; uv resolver
+# is much faster than pip for the lotus-ai dep tree (torch + transformers
+# resolution can take 5+ minutes on plain pip).
+COPY requirements.txt ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    pip install --no-cache-dir uv && \
+    uv pip install --system -r requirements.txt
+
+# Copy source
+COPY api ./api
+COPY services ./services
+COPY main.py ./
+
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 2025
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:2025/health', timeout=4)" || exit 1
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "2025"]

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -26,8 +26,8 @@ name: sparkflow
 # workflows-api, migrate). Anchors are merged into each service's
 # environment via `<<: [*no_proxy_env, *ca_cert_env]`.
 x-no-proxy-env: &no_proxy_env
-  NO_PROXY: ${NO_PROXY:-localhost,127.0.0.1},postgres,redis,searxng,web,workflows-api,ingest-worker,digest-worker,migrate
-  no_proxy: ${no_proxy:-localhost,127.0.0.1},postgres,redis,searxng,web,workflows-api,ingest-worker,digest-worker,migrate
+  NO_PROXY: ${NO_PROXY:-localhost,127.0.0.1},postgres,redis,searxng,semops,web,workflows-api,ingest-worker,digest-worker,migrate
+  no_proxy: ${no_proxy:-localhost,127.0.0.1},postgres,redis,searxng,semops,web,workflows-api,ingest-worker,digest-worker,migrate
 
 # Corporate CA bundle env vars — paired with the bind-mount of
 # ./ca-certificates.crt onto /etc/ssl/certs/ca-certificates.crt below.
@@ -111,6 +111,12 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  semops:
+    environment:
+      <<: [*no_proxy_env, *ca_cert_env]
+    volumes:
+      - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+
   digest-worker:
     build:
       context: ./apps/langgraph
@@ -122,13 +128,15 @@ services:
       <<: [*no_proxy_env, *ca_cert_env]
       REDIS_URL: redis://redis:6379
       SPARKFLOW_API_URL: ${SPARKFLOW_API_URL}
-      SEMOPS_API_URL: ${SEMOPS_API_URL}
+      SEMOPS_API_URL: ${SEMOPS_API_URL:-http://semops:2025}
       INTERNAL_CALLBACK_TOKEN: ${INTERNAL_CALLBACK_TOKEN}
       DIGEST_WORKER_CONCURRENCY: ${DIGEST_WORKER_CONCURRENCY:-4}
     volumes:
       - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
     depends_on:
       redis:
+        condition: service_healthy
+      semops:
         condition: service_healthy
     restart: unless-stopped
 
@@ -146,7 +154,7 @@ services:
       REDIS_URL: redis://redis:6379
       DATABASE_URL: postgresql://${POSTGRES_USER:-sparkflow}:${POSTGRES_PASSWORD:-sparkflow}@postgres:5432/${POSTGRES_DB:-sparkflow}
       SPARKFLOW_API_URL: ${SPARKFLOW_API_URL:-http://web:3001}
-      SEMOPS_API_URL: ${SEMOPS_API_URL:-http://host.docker.internal:2025}
+      SEMOPS_API_URL: ${SEMOPS_API_URL:-http://semops:2025}
       SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       INTERNAL_CALLBACK_TOKEN: ${INTERNAL_CALLBACK_TOKEN}
     ports:
@@ -157,6 +165,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      semops:
         condition: service_healthy
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,27 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # SemOps — LOTUS-backed semantic operators (sem_rank etc.) used by the
+  # matcher / daily_digest / search workflows in apps/langgraph. Stateless
+  # FastAPI service; no DB, no Redis. First build is slow (lotus-ai pulls
+  # torch + transformers + faiss-cpu).
+  semops:
+    build:
+      context: ./apps/semops
+      dockerfile: Dockerfile
+      additional_contexts:
+        certs: ./
+    container_name: sparkflow-semops
+    ports:
+      - "${SEMOPS_PORT:-2025}:2025"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:2025/health', timeout=4)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+
   digest-worker:
     build:
       context: ./apps/langgraph
@@ -92,14 +113,16 @@ services:
     command: ["arq", "workflows.digest_worker.WorkerSettings"]
     env_file: ./apps/langgraph/.env
     environment:
-      # Override host-side localhost URL with docker service hostname.
+      # Override host-side localhost URLs with docker service hostnames.
       REDIS_URL: redis://redis:6379
       SPARKFLOW_API_URL: ${SPARKFLOW_API_URL}
-      SEMOPS_API_URL: ${SEMOPS_API_URL}
+      SEMOPS_API_URL: ${SEMOPS_API_URL:-http://semops:2025}
       INTERNAL_CALLBACK_TOKEN: ${INTERNAL_CALLBACK_TOKEN}
       DIGEST_WORKER_CONCURRENCY: ${DIGEST_WORKER_CONCURRENCY:-4}
     depends_on:
       redis:
+        condition: service_healthy
+      semops:
         condition: service_healthy
     restart: unless-stopped
 
@@ -125,7 +148,7 @@ services:
       REDIS_URL: redis://redis:6379
       DATABASE_URL: postgresql://${POSTGRES_USER:-sparkflow}:${POSTGRES_PASSWORD:-sparkflow}@postgres:5432/${POSTGRES_DB:-sparkflow}
       SPARKFLOW_API_URL: ${SPARKFLOW_API_URL:-http://web:3001}
-      SEMOPS_API_URL: ${SEMOPS_API_URL:-http://host.docker.internal:2025}
+      SEMOPS_API_URL: ${SEMOPS_API_URL:-http://semops:2025}
       # SearXNG runs in the same compose network — use the service name.
       SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       INTERNAL_CALLBACK_TOKEN: ${INTERNAL_CALLBACK_TOKEN}
@@ -135,6 +158,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      semops:
         condition: service_healthy
     restart: unless-stopped
 


### PR DESCRIPTION
apps/semops was previously deployed as a host-side process (uvicorn running outside docker), with SEMOPS_API_URL defaulting to host.docker.internal:2025 from inside the compose network. Move it into the same compose stack so the whole monorepo (postgres / redis / searxng / web / agent / semops / workers) is one `docker compose up`.

Changes:
- apps/semops/Dockerfile (new): python:3.12-slim + lotus-ai deps via uv. python:3.13 was tried first but lotus-ai 1.1.x pins numpy==1.26.4, which has no 3.13 wheel and its sdist build fails. Pin to 3.12 until lotus-ai bumps its numpy floor.
- apps/semops/.dockerignore (new): the usual __pycache__/.venv/tests/ exclusions so build context stays small.
- docker-compose.yml: new `semops` service in the default profile (dev uses it too; not prod-only) with /health healthcheck. SEMOPS_API_URL defaults shifted from host.docker.internal:2025 → semops:2025 (compose service hostname). Both digest-worker and workflows-api gain `depends_on: semops: service_healthy`.
- docker-compose.server.yml: same SEMOPS_API_URL default + depends_on updates; added a semops override block for the corp-network NO_PROXY
  + CA cert wiring (the LOTUS LLM ranking calls openai/gemini and needs the CA bundle on TLS-MITM networks). Added `semops` to the NO_PROXY anchor.
- README.md: dev-mode section notes semops is in compose now and how to opt out (run on host) for faster LOTUS iteration.
- Uses additional_contexts: { certs: ./ } from the previous commit so the single root ca-certificates.crt covers semops too.

Verified:
- `docker compose --profile prod config` valid
- `docker compose -f docker-compose.yml -f docker-compose.server.yml --profile prod config` valid
- `docker compose build semops` succeeds (~3GB image, mostly torch + transformers + faiss-cpu + sentence-transformers from lotus-ai)
- semops container healthy: GET /health → {"status":"healthy","service":"semops"}