### PR TITLE
feat(compose): postgres-init service auto-creates sparkflow_checkpoints

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -29,6 +29,37 @@ services:
       timeout: 5s
       retries: 5
 
+  # One-shot postgres bootstrap. Creates sparkflow_checkpoints (used by the
+  # langgraph CLI's --postgres-uri so it doesn't need to spin up a sibling
+  # langgraph-postgres of its own — corp-network docker DNS can't resolve
+  # sibling hostnames reliably). Idempotent: skips when the DB already
+  # exists, so re-running `up -d` is safe. `restart: "no"` because this
+  # exits 0 once done.
+  postgres-init:
+    image: pgvector/pgvector:pg17
+    container_name: sparkflow-postgres-init
+    env_file: ./.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    entrypoint: []
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        export PGPASSWORD="$$POSTGRES_PASSWORD"
+        if psql -h postgres -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" -tAc \
+             "SELECT 1 FROM pg_database WHERE datname='sparkflow_checkpoints'" \
+             | grep -q 1; then
+          echo "[postgres-init] sparkflow_checkpoints already exists"
+        else
+          psql -h postgres -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" \
+            -c "CREATE DATABASE sparkflow_checkpoints"
+          echo "[postgres-init] created sparkflow_checkpoints"
+        fi
+    restart: "no"
+
   redis:
     image: redis:7-alpine
     container_name: sparkflow-redis


### PR DESCRIPTION
The langgraph CLI's `langgraph up` defaults to spinning up its own sibling postgres for the checkpointer, but Docker's embedded DNS on corp-network hosts mis-resolves sibling hostnames ("lookup langgraph-postgres on 127.0.0.11:53: server misbehaving") and the agent crashes on startup. Workaround is `--postgres-uri` pointing at the existing sparkflow postgres — which requires a sparkflow_checkpoints database to exist.

Previously this was a manual `docker exec sparkflow-postgres psql ... -c 'CREATE DATABASE sparkflow_checkpoints'` step the operator had to remember post-deploy. Bake it into compose as a one-shot init service so a fresh `up -d --build` leaves the cluster ready for `langgraph up` immediately.

Idempotent: the init service guards with a `SELECT 1 FROM pg_database` check, so re-running compose is a no-op when the DB already exists. `restart: "no"` because it's a one-shot.