### PR TITLE
fix(langgraph make/up): wire CHECKPOINT_DB_URL to in-container hostname

### DIFF
--- a/apps/langgraph/Makefile
+++ b/apps/langgraph/Makefile
@@ -22,6 +22,16 @@ else
 COMPOSE_FLAG :=
 endif
 
+# Auto-load .env so CHECKPOINT_DB_URL, DATABASE_URL, etc. are visible to
+# Make. langgraph CLI loads .env into the agent process via `env: .env` in
+# langgraph.json, but Make runs *before* the CLI — without this include, Make
+# sees CHECKPOINT_DB_URL as empty and `--postgres-uri` is never passed, so
+# `langgraph up` falls back to its sibling postgres (which fails to resolve
+# on corp-network hosts where embedded Docker DNS is broken). `-include` so a
+# missing .env doesn't error; values stay Make-local (no `export`) to keep
+# secrets like LANGSMITH_API_KEY out of recipe sub-shells.
+-include .env
+
 # Optional: point langgraph at an external Postgres for the checkpointer
 # instead of letting `langgraph up` spin up its own `langgraph-postgres`
 # sibling. Two scenarios where this is needed:
@@ -32,11 +42,16 @@ endif
 #      (langgraph's sibling lives in a CLI-managed volume that's easy to
 #      blow away accidentally).
 # When set, this is passed as `--postgres-uri` to `langgraph up`.
-# Read from .env automatically because `langgraph.json` declares `env: .env`,
-# but we ALSO surface it on the Make command line so the CLI sees it before
-# launching docker compose.
+#
+# CHECKPOINT_DB_URL in .env uses `@localhost:5433` so `make dev` (host-side
+# `langgraph dev`) can reach apps/web's postgres directly. `make up` runs
+# the same agent inside a container where `localhost` is the container, not
+# the host — so we rewrite `@localhost:` → `@host.docker.internal:` only
+# when constructing POSTGRES_FLAG. Containers see the right address; .env
+# stays single-source-of-truth.
 ifneq ($(CHECKPOINT_DB_URL),)
-POSTGRES_FLAG := --postgres-uri "$(CHECKPOINT_DB_URL)"
+DOCKER_CHECKPOINT_DB_URL := $(subst @localhost:,@host.docker.internal:,$(CHECKPOINT_DB_URL))
+POSTGRES_FLAG := --postgres-uri "$(DOCKER_CHECKPOINT_DB_URL)"
 else
 POSTGRES_FLAG :=
 endif

--- a/apps/langgraph/docker-compose.override.yml.example
+++ b/apps/langgraph/docker-compose.override.yml.example
@@ -22,6 +22,15 @@ services:
       REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       CURL_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       LANGGRAPH_API_HOST: 0.0.0.0
+      # `localhost` in .env is the host's perspective (used by `make dev`).
+      # Inside the container, `localhost` is the container itself — so
+      # rewrite both URLs to `host.docker.internal:5433` (apps/web's
+      # postgres). Same pattern docker-compose.server.yml uses for the web
+      # / worker services that reach a sibling postgres. Without this the
+      # agent code uses .env's localhost and fails inside the container,
+      # even after the runtime's --postgres-uri starts working.
+      DATABASE_URL: postgresql://sparkflow:sparkflow@host.docker.internal:5433/sparkflow
+      CHECKPOINT_DB_URL: postgresql://sparkflow:sparkflow@host.docker.internal:5433/sparkflow_checkpoints
       # On hosts where ~/.docker/config.json injects HTTP_PROXY/HTTPS_PROXY into
       # every container (corp networks), NO_PROXY must list every sibling
       # service hostname so postgres/redis traffic doesn't get proxied. Both


### PR DESCRIPTION
`make up` was failing on corp-network hosts with `lookup langgraph-postgres on 127.0.0.11:53: server misbehaving` because two pieces of the design weren't connecting:

  1. Make didn't read .env, so $(CHECKPOINT_DB_URL) was always empty and `--postgres-uri` was never passed to `langgraph up`. The CLI defaulted to its sibling postgres, whose hostname embedded-DNS can't resolve when corp /etc/resolv.conf overrides 127.0.0.11.
  2. Even when --postgres-uri *was* set, the URL in .env uses `@localhost:5433` (right for `make dev` on the host, wrong from inside a container where localhost is the container).

Fix:
  - Makefile `-include .env` so CHECKPOINT_DB_URL flows through (no `export` so secrets don't reach recipe sub-shells).
  - Rewrite `@localhost:` → `@host.docker.internal:` only when constructing POSTGRES_FLAG. .env stays single-source-of-truth; `make dev` still uses the original localhost URL.
  - docker-compose.override.yml.example: pin DATABASE_URL and CHECKPOINT_DB_URL to host.docker.internal:5433 so the agent code (which reads them from env, not the CLI flag) also routes correctly.