### PR TITLE
fix(langgraph compose override): pin sibling images to cached tags

### DIFF
--- a/apps/langgraph/docker-compose.override.yml.example
+++ b/apps/langgraph/docker-compose.override.yml.example
@@ -6,6 +6,28 @@
 # (apps/langgraph/Makefile auto-attaches the file with `-d` when it exists.)
 
 services:
+  # Pin the sibling images to tags the SparkFlow stack already pulled
+  # (apps/web's `docker compose up` brings up `pgvector/pgvector:pg17` and
+  # `redis:7-alpine`). Without this, `langgraph up` tries to pull the CLI's
+  # default `redis:6` / `postgres:16` from Docker Hub — and on corp-MITM
+  # hosts where the Docker *daemon* doesn't trust the proxy CA, every
+  # registry pull dies with `x509: certificate signed by unknown authority`
+  # before any container even starts. Reusing already-cached images
+  # sidesteps the daemon trust store entirely.
+  #
+  # Long-term fix is host-side: install your corp CA into Docker's trust
+  # store (e.g. /etc/docker/certs.d/<registry>/ca.crt + restart docker, or
+  # add to /etc/ssl/certs/ca-certificates.crt and `update-ca-certificates`).
+  # Until then, the image pin keeps `make up` working.
+  #
+  # The langgraph-postgres sibling is *unused* once --postgres-uri redirects
+  # to apps/web's postgres — but `langgraph up` always brings it up anyway,
+  # so it still needs an image that can be loaded.
+  langgraph-postgres:
+    image: pgvector/pgvector:pg17
+  langgraph-redis:
+    image: redis:7-alpine
+
   langgraph-api:
     # Make `host.docker.internal` resolvable from inside the container on
     # Linux (it's automatic on Docker Desktop). Required when CHECKPOINT_DB_URL


### PR DESCRIPTION
`make up` was dying at image pull on corp-MITM hosts:
  Image redis:6 Pulling
  ... tls: failed to verify certificate: x509: certificate signed by
  unknown authority

The Docker *daemon* (not the container) makes the registry request, so the in-container CA bundle wired up earlier doesn't help. The proper host-side fix is to install the corp CA into Docker's trust store, but that needs root + a daemon restart on the server.

Quick unblock: pin `langgraph-postgres` to `pgvector/pgvector:pg17` and `langgraph-redis` to `redis:7-alpine` in the override. Both tags are already in the local cache from `docker compose up -d` for the SparkFlow stack, so no registry round-trip is needed. The langgraph-postgres sibling is unused once `--postgres-uri` redirects to apps/web's postgres, but `langgraph up` brings it up regardless — it just needs *some* image that can be loaded.

Override comment also documents the long-term host-side fix so this doesn't become tribal knowledge.