### PR TITLE
fix(langgraph chat): preserve DeepSeek reasoning_content across turns

### DIFF
--- a/apps/langgraph/_reasoning_patch.py
+++ b/apps/langgraph/_reasoning_patch.py
@@ -1,0 +1,50 @@
+"""Monkey-patch langchain-openai so DeepSeek's reasoning_content roundtrips.
+
+DeepSeek's thinking-mode API requires that prior assistant turns carry
+their `reasoning_content` on every continuation request — see
+https://api-docs.deepseek.com/guides/thinking_mode. ChatDeepSeek captures
+the field into AIMessage.additional_kwargs on inbound responses (see
+langchain_deepseek.chat_models lines ~315-327), but
+langchain-openai's `_convert_message_to_dict` only extracts a small
+whitelist of keys (`name`, `tool_calls`, `function_call`, `audio`) from
+additional_kwargs — `reasoning_content` is dropped during serialization.
+The second turn of any multi-turn conversation (especially after a tool
+call) then 400s with `Missing reasoning_content field in the assistant
+message` or `The reasoning_content in the thinking mode must be passed
+back to the API`.
+
+Upstream tracking: https://github.com/langchain-ai/langchain/issues/34166.
+Until that lands, wrap the converter so AIMessages with
+additional_kwargs.reasoning_content carry that field into the outgoing
+payload. Idempotent (safe to import multiple times). No-op for messages
+without reasoning_content, so non-DeepSeek providers and DeepSeek's
+non-thinking models (deepseek-chat) are unaffected.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage
+from langchain_openai.chat_models import base as _openai_base
+
+_PATCH_FLAG = "_sparkflow_reasoning_content_patched"
+# Stash the original on the langchain module itself so module reloads
+# resolve "orig" from the langchain attribute (still the real original)
+# rather than re-reading the already-patched module-level binding (which
+# would make the wrapper recurse into itself).
+_ORIG_ATTR = "_sparkflow_reasoning_content_orig"
+
+
+def _patched_convert_message_to_dict(message, api="chat/completions"):
+    orig = getattr(_openai_base, _ORIG_ATTR)
+    payload = orig(message, api=api)
+    if isinstance(message, AIMessage):
+        rc = (message.additional_kwargs or {}).get("reasoning_content")
+        if rc and "reasoning_content" not in payload:
+            payload["reasoning_content"] = rc
+    return payload
+
+
+if not getattr(_openai_base, _PATCH_FLAG, False):
+    setattr(_openai_base, _ORIG_ATTR, _openai_base._convert_message_to_dict)
+    _openai_base._convert_message_to_dict = _patched_convert_message_to_dict
+    setattr(_openai_base, _PATCH_FLAG, True)

--- a/apps/langgraph/agents/deep_research.py
+++ b/apps/langgraph/agents/deep_research.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
+import _reasoning_patch  # noqa: F401  — preserves DeepSeek reasoning_content across turns
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, START, MessagesState, StateGraph

--- a/apps/langgraph/agents/hub.py
+++ b/apps/langgraph/agents/hub.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
+import _reasoning_patch  # noqa: F401  — preserves DeepSeek reasoning_content across turns
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, START, MessagesState, StateGraph

--- a/apps/langgraph/agents/notebook.py
+++ b/apps/langgraph/agents/notebook.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
+import _reasoning_patch  # noqa: F401  — preserves DeepSeek reasoning_content across turns
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
 from langgraph.graph import END, START, MessagesState, StateGraph


### PR DESCRIPTION
Multi-turn chat with DeepSeek's reasoning model 400'd on the second turn with `The reasoning_content in the thinking mode must be passed back to the API`. Tracking issue: langchain-ai/langchain#34166.

Root cause confirmed by reading both packages' sources:
- langchain_deepseek.chat_models lines ~315-327 capture the model's `reasoning_content` into `AIMessage.additional_kwargs` on inbound responses (both streaming chunks and full responses).
- langchain_openai.chat_models.base._convert_message_to_dict (line 346) only extracts a small whitelist of keys (`name`, `tool_calls`, `function_call`, `audio`) from additional_kwargs when serializing AIMessages back to the API. `reasoning_content` is silently dropped.
- DeepSeek's thinking-mode API requires that prior assistant turns include their reasoning_content on every continuation request (https://api-docs.deepseek.com/guides/thinking_mode). The dropped field is exactly what triggers the 400.

Fix: import-time monkey-patch on _convert_message_to_dict that re-injects `reasoning_content` from additional_kwargs into the outgoing payload. The patch is idempotent and reload-safe (stashes the original on the langchain module so a re-import doesn't recurse into the wrapper). It's a no-op for AIMessages without reasoning_content, so non-DeepSeek providers and DeepSeek's non-thinking models (deepseek-chat) are unaffected.

Wired into all three agents that go through init_chat_model → ChatDeepSeek (notebook, hub, deep_research). wiki_ingest is single-shot and doesn't hit the multi-turn path, so it doesn't need the import.

Tested: AIMessage with reasoning_content + tool_calls (the actual bug scenario) now serializes both fields; AIMessage without reasoning_content gets no spurious key; reload-safe.