### PR TITLE
fix(notebook agent): emit notebook_id in system prompt; wire wiki tools

### DIFF
--- a/apps/langgraph/agents/deep_research.py
+++ b/apps/langgraph/agents/deep_research.py
@@ -41,6 +41,8 @@ def llm_call(state: MessagesState, runtime: Runtime[Ctx]) -> dict[str, list[Base
         provider=ctx.model_provider,
         model=ctx.model_name,
         session_id=ctx.session_id,
+        notebook_id=ctx.notebook_id,
+        user_id=ctx.user_id,
         page_context=ctx.page_context,
     )
     model = init_chat_model(f"{ctx.model_provider}:{ctx.model_name}", api_key=ctx.api_key)

--- a/apps/langgraph/agents/hub.py
+++ b/apps/langgraph/agents/hub.py
@@ -53,6 +53,8 @@ def llm_call(state: MessagesState, runtime: Runtime[Ctx]) -> dict[str, list[Base
         provider=ctx.model_provider,
         model=ctx.model_name,
         session_id=ctx.session_id,
+        notebook_id=ctx.notebook_id,
+        user_id=ctx.user_id,
         page_context=ctx.page_context,
     )
     model = init_chat_model(f"{ctx.model_provider}:{ctx.model_name}", api_key=ctx.api_key)

--- a/apps/langgraph/agents/notebook.py
+++ b/apps/langgraph/agents/notebook.py
@@ -14,9 +14,9 @@ from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolM
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.runtime import Runtime
 from prompt_builder import build_system_prompt
-from tools.wiki import source_list, source_read
+from tools.wiki import source_list, source_read, wiki_list, wiki_read
 
-TOOLS = [source_read, source_list]
+TOOLS = [source_read, source_list, wiki_read, wiki_list]
 TOOLS_BY_NAME = {t.name: t for t in TOOLS}
 SURFACE = "notebook"
 PROMPT_PATH = "surfaces/notebook.md"
@@ -43,6 +43,8 @@ def llm_call(state: MessagesState, runtime: Runtime[Ctx]) -> dict[str, list[Base
         provider=ctx.model_provider,
         model=ctx.model_name,
         session_id=ctx.session_id,
+        notebook_id=ctx.notebook_id,
+        user_id=ctx.user_id,
         page_context=ctx.page_context,
     )
     model = init_chat_model(f"{ctx.model_provider}:{ctx.model_name}", api_key=ctx.api_key)

--- a/apps/langgraph/prompt_builder.py
+++ b/apps/langgraph/prompt_builder.py
@@ -52,6 +52,8 @@ def build_system_prompt(
     provider: str,
     model: str,
     session_id: str,
+    notebook_id: str | None = None,
+    user_id: str | None = None,
     page_context: str | None = None,
 ) -> str:
     parts: list[str] = [
@@ -62,11 +64,21 @@ def build_system_prompt(
     ]
     if page_context:
         parts.append(f"## Current page context\n\n- {page_context}")
-    parts.append(
-        "## Session Metadata\n\n"
-        f"- session_id: `{session_id}`\n"
-        f"- surface: `{surface}`\n"
-        f"- model: `{provider}/{model}`\n"
-        f"- timestamp: `{datetime.now(timezone.utc).isoformat()}`"
-    )
+    # Emit notebook_id / user_id when present. The notebook surface prompt
+    # instructs the LLM to "always pass notebook_id from session metadata"
+    # when calling source_read / source_list — without these lines, every
+    # tool call goes through with an empty notebook_id and the tool
+    # returns "No notebook context available", which is why chat appears
+    # to not see the wiki / source content at all.
+    metadata_lines = [
+        f"- session_id: `{session_id}`",
+        f"- surface: `{surface}`",
+        f"- model: `{provider}/{model}`",
+    ]
+    if notebook_id:
+        metadata_lines.append(f"- notebook_id: `{notebook_id}`")
+    if user_id:
+        metadata_lines.append(f"- user_id: `{user_id}`")
+    metadata_lines.append(f"- timestamp: `{datetime.now(timezone.utc).isoformat()}`")
+    parts.append("## Session Metadata\n\n" + "\n".join(metadata_lines))
     return "\n\n".join(p for p in parts if p)

--- a/apps/langgraph/prompts/surfaces/notebook.md
+++ b/apps/langgraph/prompts/surfaces/notebook.md
@@ -2,29 +2,35 @@
 You are a research assistant for a notebook. You help the user understand their uploaded papers and documents.
 
 # How You Work (invisible to user)
-You have two layers of knowledge:
-1. **Wiki summaries** — pre-compiled knowledge injected as system context. Use this to understand the big picture, relationships between concepts, and to connect dots across sources.
-2. **Original sources** — full documents the user uploaded. Use tools to read these for specifics.
+You have two layers of knowledge, both fetched on demand via tools:
+1. **Wiki summaries** (`wiki_list` / `wiki_read`) — auto-compiled topic pages built from the knowledge graph. Each page groups related entities and cites the underlying sources via [source:id] backlinks. Use these for the big picture, relationships between concepts, and to connect dots across sources.
+2. **Original sources** (`source_list` / `source_read`) — full documents the user uploaded. Use these for specifics: loss functions, algorithms, formulas, exact methods, numbers, implementation details.
 
 IMPORTANT: The user should never feel like they're talking to a "knowledge graph" or "wiki system". They should feel like they're talking to a brilliant research assistant who has deeply read all their papers and naturally connects ideas across them. Never say "in the knowledge graph", "according to the wiki", "the notebook's knowledge network", or similar phrases. Just present the information as if you know it from reading the papers.
 
 # Tools
-- `source_read(source_id)` — Read the FULL raw content of an original source document.
-- `source_list()` — List all source documents with their IDs.
+- `wiki_list()` — List auto-generated wiki topic pages with titles and slugs.
+- `wiki_read(slug)` — Read the FULL markdown of one wiki page. Returns a synthesized topic summary with [source:id] backlinks.
+- `source_list()` — List all original source documents with their IDs.
+- `source_read(source_id)` — Read the FULL raw content of one original source document.
 
-# CRITICAL: Always Check Sources for Detail
-When the user asks about specifics — loss functions, algorithms, formulas, exact methods, numbers, implementation details, experimental results — you MUST:
-1. Call `source_list()` to get available source IDs
+# CRITICAL: Always Read Before Answering
+Never answer "information not available" or "I don't have access to your sources" without first calling these tools. The notebook's content is reachable — you just have to fetch it.
+
+For OVERVIEW or "what does this notebook contain" questions:
+1. Call `wiki_list()` to discover topic pages
+2. Call `wiki_read(slug)` on the relevant page(s)
+3. Synthesize from the wiki content; cite original sources via [source:id]
+
+For SPECIFIC questions (loss functions, algorithms, formulas, exact methods, numbers, experimental results):
+1. Call `source_list()` to get available source IDs (and/or `wiki_read` first for orientation)
 2. Call `source_read(source_id)` on the relevant source
 3. Answer from the full source text
 
-NEVER say "information not available" without first calling source_read.
-
 # Answering Flow
-1. Use wiki context to understand what concepts exist and how they relate
-2. For overview questions: synthesize from your wiki knowledge, cite original sources
-3. For detailed questions: call source_read() → answer from the full document
-4. Always cite the ORIGINAL SOURCE, not the wiki
+1. For broad questions: wiki_list → wiki_read → synthesize → cite original sources
+2. For detailed questions: source_list → source_read → answer from the full document
+3. Always cite the ORIGINAL SOURCE in [source:id] form, not the wiki page slug
 
 # Citations
 - Use [source:id] to cite original documents (the user sees the paper title)

--- a/apps/langgraph/tools/wiki.py
+++ b/apps/langgraph/tools/wiki.py
@@ -1,7 +1,18 @@
-"""LangChain tools for reading source documents.
+"""LangChain tools for reading the notebook's wiki pages and source documents.
 
-Used by the notebook agent to access original source content when wiki
-summaries lack detail.
+`source_*` tools fetch the original uploaded content (PDFs, web pages,
+markdown) — use them when the wiki summary lacks detail.
+
+`wiki_*` tools fetch the auto-generated wiki: per-community pages built
+from the knowledge graph (entities → topics → markdown summaries with
+[source:id] backlinks). Use them for the big picture and for connecting
+concepts across multiple sources.
+
+Both rely on `notebook_id` being available to the LLM via the session
+metadata block emitted by `prompt_builder.build_system_prompt`. The
+endpoints they hit are intentionally unauthenticated GETs (see
+apps/web/app/api/notebooks/[id]/wiki/route.ts) so the langgraph agent
+can call them without forwarding session cookies.
 """
 
 import os
@@ -79,4 +90,75 @@ def source_list(notebook_id: str) -> str:
         return f"Error listing sources: {e}"
 
 
-wiki_tools = [source_read, source_list]
+@tool
+def wiki_list(notebook_id: str) -> str:
+    """List the auto-generated wiki pages for the notebook.
+
+    Wiki pages are markdown summaries auto-built from the knowledge
+    graph: each page groups related entities into a topic and cites the
+    original sources via [source:id] backlinks. Call this first to
+    discover what topics the notebook covers, then call `wiki_read` to
+    drill into a specific page.
+
+    Args:
+        notebook_id: The notebook (from session metadata).
+    """
+    if not notebook_id:
+        return "No notebook context available."
+
+    try:
+        res = httpx.get(
+            f"{SPARKFLOW_API_URL}/api/notebooks/{notebook_id}/wiki",
+            timeout=30,
+        )
+        if not res.is_success:
+            return f"Failed to list wiki pages: {res.status_code}"
+        pages = res.json().get("pages", [])
+        if not pages:
+            return "No wiki pages in this notebook yet (sources may still be ingesting)."
+        lines = ["# Wiki Pages\n"]
+        for p in pages:
+            page_type = p.get("pageType", "PAGE")
+            lines.append(f"- **{p['title']}** [{p['slug']}] (type: {page_type})")
+        return "\n".join(lines)
+    except Exception as e:
+        return f"Error listing wiki pages: {e}"
+
+
+@tool
+def wiki_read(notebook_id: str, slug: str) -> str:
+    """Read the full markdown content of a single wiki page.
+
+    Use this after `wiki_list` to read a specific topic page — it gives
+    a synthesized overview across multiple sources, with [source:id]
+    citations you can follow up on with `source_read`.
+
+    Args:
+        notebook_id: The notebook (from session metadata).
+        slug: The wiki page slug (from `wiki_list`, e.g. "community-3").
+    """
+    if not notebook_id:
+        return "No notebook context available."
+
+    try:
+        res = httpx.get(
+            f"{SPARKFLOW_API_URL}/api/notebooks/{notebook_id}/wiki/{slug}",
+            timeout=30,
+        )
+        if res.status_code == 404:
+            return f"Wiki page '{slug}' not found."
+        if not res.is_success:
+            return f"Failed to read wiki page: {res.status_code}"
+        data = res.json()
+        title = data.get("title", "")
+        content = data.get("content", "")
+        # Truncate aggressively — wiki pages can be large after several
+        # ingest passes, and the LLM also has the source_read fallback.
+        if len(content) > 20000:
+            content = content[:20000] + "\n\n[... content truncated, use source_read for specifics ...]"
+        return f"# {title}\n\n{content}" if content else "Wiki page has no content."
+    except Exception as e:
+        return f"Error reading wiki page: {e}"
+
+
+wiki_tools = [source_read, source_list, wiki_list, wiki_read]


### PR DESCRIPTION
Two related bugs that made the notebook agent appear blind to both the wiki and the source content.

(1) `Ctx.notebook_id` was reaching the agent (chat-panel sends it via
    `context.notebook_id` in the langgraph stream) but never made it
    into the system prompt. The notebook surface prompt instructs the
    LLM to "always pass notebook_id from session metadata" before
    calling source_read / source_list — so the LLM saw an empty session
    metadata block, called the tools without notebook_id, and got back
    "No notebook context available." Every chat answer then read like
    "I don't have access to your sources."

    Fixed in prompt_builder.build_system_prompt: accept and render
    notebook_id and user_id in the metadata block when present.
    Threaded through llm_call in all three agents (notebook / hub /
    deep_research).

(2) The notebook surface prompt claimed "Wiki summaries — pre-compiled
    knowledge injected as system context", but no injection actually
    happened and there were no wiki_* tools either. Added
    wiki_list / wiki_read tools (matching the source_list / source_read
    pair) that hit the existing unauthenticated GET endpoints
    apps/web/app/api/notebooks/[id]/wiki and
    /api/notebooks/[id]/wiki/[slug] (those endpoints' comments
    explicitly note they're left unauth so the langgraph agent can
    reach them without forwarding session cookies — they were just
    never called). Bound them in the notebook agent's TOOLS list.

    Surface prompt rewritten to match reality: wiki content is fetched
    on demand via wiki_list/wiki_read, sources via
    source_list/source_read. No more dangling claim about injected
    context.