### PR TITLE
fix(research-hub): guard against undefined externalId before stream

### DIFF
--- a/apps/web/components/explore/explore-shell.tsx
+++ b/apps/web/components/explore/explore-shell.tsx
@@ -111,7 +111,16 @@ function ExploreShellInner({ children, user }: ExploreShellProps) {
       // "invalid thread ID; invalid UUID format" because that release
       // strictly validates thread_id is a UUID (server log showed
       // `invalid UUID length: 17`).
+      //
+      // The narrowing guard mirrors createLangGraphStream.js:9-10 — if
+      // initialize() somehow returned without an externalId, the
+      // `create()` callback below either failed or was never reached, and
+      // there's no point passing undefined down to the SDK (which types
+      // threadId as `string | null` only).
       const { externalId } = await initialize();
+      if (!externalId) {
+        throw new Error("Thread has not been initialized.");
+      }
 
       return langGraphClient.runs.stream(externalId, "hub", {
         input: { messages },


### PR DESCRIPTION
Build was failing TypeScript: `runs.stream(threadId, ...)` types threadId as `string | null`, never `string | undefined`. After the previous `{ externalId } = await initialize()` change, externalId narrows to `string | undefined`, which doesn't satisfy either overload.

Add the same narrowing guard the SDK's reference impl uses (@assistant-ui/react-langgraph/dist/createLangGraphStream.js:9-10): throw "Thread has not been initialized." if externalId is missing. That makes the type concrete (`string`) and surfaces a real error instead of letting undefined slip through.