### PR TITLE
fix(agents): set ToolMessage(name=...) so assistant-ui converter acce…

### DIFF
--- a/apps/langgraph/agents/deep_research.py
+++ b/apps/langgraph/agents/deep_research.py
@@ -65,6 +65,7 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
                 ToolMessage(
                     content=json.dumps({"error": f"unknown tool {call['name']}"}),
                     tool_call_id=call["id"],
+                    name=call["name"],
                 )
             )
             continue
@@ -76,7 +77,8 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
         except Exception as exc:
             raw = {"error": str(exc)}
         content = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)
-        results.append(ToolMessage(content=content, tool_call_id=call["id"]))
+        # See hub.py for why `name=` is required (assistant-ui converter).
+        results.append(ToolMessage(content=content, tool_call_id=call["id"], name=call["name"]))
     return {"messages": results}
 
 

--- a/apps/langgraph/agents/hub.py
+++ b/apps/langgraph/agents/hub.py
@@ -80,6 +80,7 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
                 ToolMessage(
                     content=json.dumps({"error": f"unknown tool {call['name']}"}),
                     tool_call_id=call["id"],
+                    name=call["name"],
                 )
             )
             continue
@@ -91,7 +92,13 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
         except Exception as exc:
             raw = {"error": str(exc)}
         content = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)
-        results.append(ToolMessage(content=content, tool_call_id=call["id"]))
+        # Set `name=` so the streamed ToolMessage carries the tool name back
+        # to the frontend. assistant-ui's external-message-converter treats
+        # `null !== expected_name` as a hard error and refuses to render the
+        # rest of the conversation (see @assistant-ui/core/.../external-
+        # message-converter.js:28). LangChain ToolMessage's `name` defaults
+        # to None — passing it explicitly keeps the converter happy.
+        results.append(ToolMessage(content=content, tool_call_id=call["id"], name=call["name"]))
     return {"messages": results}
 
 

--- a/apps/langgraph/agents/notebook.py
+++ b/apps/langgraph/agents/notebook.py
@@ -67,6 +67,7 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
                 ToolMessage(
                     content=json.dumps({"error": f"unknown tool {call['name']}"}),
                     tool_call_id=call["id"],
+                    name=call["name"],
                 )
             )
             continue
@@ -78,7 +79,8 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
         except Exception as exc:  # noqa: BLE001
             raw = {"error": str(exc)}
         content = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)
-        results.append(ToolMessage(content=content, tool_call_id=call["id"]))
+        # See hub.py for why `name=` is required (assistant-ui converter).
+        results.append(ToolMessage(content=content, tool_call_id=call["id"], name=call["name"]))
     return {"messages": results}
 
 


### PR DESCRIPTION
…pts it

Research hub crashed in the browser with:

  Error: Tool call name <id> null does not match existing tool call
  aggregate_publications

@assistant-ui/core's external-message-converter
(react/runtimes/external-message-converter.js:28) refuses to merge a tool result into the conversation when the result's `toolName` is non-undefined and doesn't match the assistant message's tool_call name. LangChain `ToolMessage`'s `name` field defaults to None, which is serialized as `null` over the wire — the converter sees null !== expected and throws, taking the whole panel down.

Pass `name=call["name"]` explicitly on every ToolMessage construction across all three agents (hub, notebook, deep_research) — both the unknown-tool branch and the success branch. This keeps the conversation renderable in assistant-ui without changing what the LLM sees on the next turn (it already gets `tool_call_id` for matching).

Notebook chat hadn't surfaced this because deepdive uses LangGraph SDK's `useStream` directly, which doesn't run the assistant-ui converter that makes the strict null check.