### PR TITLE
fix(agents): use ainvoke unconditionally so async tools work

### DIFF
--- a/apps/langgraph/agents/deep_research.py
+++ b/apps/langgraph/agents/deep_research.py
@@ -70,10 +70,8 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
             )
             continue
         try:
-            if asyncio.iscoroutinefunction(getattr(tool, "func", None)):
-                raw = asyncio.run(tool.ainvoke(call["args"]))
-            else:
-                raw = tool.invoke(call["args"])
+            # See hub.py for why ainvoke is unconditional.
+            raw = asyncio.run(tool.ainvoke(call["args"]))
         except Exception as exc:
             raw = {"error": str(exc)}
         content = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)

--- a/apps/langgraph/agents/hub.py
+++ b/apps/langgraph/agents/hub.py
@@ -85,10 +85,15 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
             )
             continue
         try:
-            if asyncio.iscoroutinefunction(getattr(tool, "func", None)):
-                raw = asyncio.run(tool.ainvoke(call["args"]))
-            else:
-                raw = tool.invoke(call["args"])
+            # Always use ainvoke: LangChain `@tool` on an `async def`
+            # produces a StructuredTool with `coroutine=...` and `func=None`
+            # (or a stub that raises). The previous
+            # `iscoroutinefunction(tool.func)` check returned False for
+            # async tools and the sync `tool.invoke()` fell back, raising
+            # `StructuredTool does not support sync invocation` for every
+            # async hub tool (hub_toolbox.* and hub_wechat.*). ainvoke
+            # transparently runs sync tools too, so this is the safe path.
+            raw = asyncio.run(tool.ainvoke(call["args"]))
         except Exception as exc:
             raw = {"error": str(exc)}
         content = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)

--- a/apps/langgraph/agents/notebook.py
+++ b/apps/langgraph/agents/notebook.py
@@ -72,10 +72,8 @@ def tool_node(state: MessagesState) -> dict[str, list[BaseMessage]]:
             )
             continue
         try:
-            if asyncio.iscoroutinefunction(getattr(tool, "func", None)):
-                raw = asyncio.run(tool.ainvoke(call["args"]))
-            else:
-                raw = tool.invoke(call["args"])
+            # See hub.py for why ainvoke is unconditional.
+            raw = asyncio.run(tool.ainvoke(call["args"]))
         except Exception as exc:  # noqa: BLE001
             raw = {"error": str(exc)}
         content = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)


### PR DESCRIPTION
Hub agent failed with "StructuredTool does not support sync invocation" on every database-backed tool (count_wechat_articles, aggregate_publications, etc.) because the dispatch logic checked the wrong attribute:

  if asyncio.iscoroutinefunction(getattr(tool, "func", None)):
      raw = asyncio.run(tool.ainvoke(call["args"]))
  else:
      raw = tool.invoke(call["args"])

LangChain's `@tool` on an `async def` produces a StructuredTool with `coroutine=<async fn>` and `func=None` (or a stub that raises). The check returned False for async tools, the sync branch ran `tool.invoke()`, and StructuredTool refused. Hub LLM saw the error string in every ToolMessage and gave up reading data, telling the user "backend configuration error".

Drop the branch entirely and always use `ainvoke`. It transparently runs sync tools (LangChain wraps them in run_in_executor under the hood), so notebook.py / deep_research.py with their sync source_read / source_list / wiki_read / wiki_list tools also work — verified by reading the LangChain BaseTool source.

Notebook chat hadn't surfaced this because all four wiki tools are sync `def`, so the old check happened to pick the right branch. This commit makes all three agents use the same correct pattern.