### PR TITLE
fix(matcher history): stop double-parsing Prisma Json column

### DIFF
--- a/apps/web/app/[locale]/explore/toolbox/matcher/history/page.tsx
+++ b/apps/web/app/[locale]/explore/toolbox/matcher/history/page.tsx
@@ -42,7 +42,10 @@ export default async function MatchHistoryPage({ params }: PageProps) {
   });
 
   const serializedJobs = jobs.map((job) => {
-    const queryData = job.queryData ? (JSON.parse(String(job.queryData)) as ParsedQuery[]) : null;
+    // Prisma returns Json columns as already-parsed JS values, so just
+    // cast — wrapping in JSON.parse(String(...)) gives "[object Object]"
+    // and crashes the page.
+    const queryData = (job.queryData as ParsedQuery[] | null) ?? null;
     return {
       id: job.id,
       targetType: job.targetType,


### PR DESCRIPTION
job.queryData is Prisma `Json?` — Prisma 7 returns it already deserialized. Wrapping it in JSON.parse(String(...)) stringified the object to "[object Object]" and crashed the History page with "Unexpected token 'o', '[object Obj'... is not valid JSON".

Just cast through the type — the value already matches ParsedQuery[].