### PR TITLE
fix(matcher SSE): keep stream alive past 5min on long rank stages

### DIFF
--- a/apps/langgraph/server/routes/matcher_jobs.py
+++ b/apps/langgraph/server/routes/matcher_jobs.py
@@ -146,6 +146,14 @@ async def stream_job_progress(
 
     async def event_generator():
         last_progress = None
+        # Emit an SSE comment heartbeat every HEARTBEAT_SECS even when
+        # nothing changes. Without this, long rank stages (10+ min on CPU)
+        # produce no bytes for minutes and any proxy in the path
+        # (undici/Next.js, nginx, cloudflare) will kill the stream on its
+        # body-timeout. SSE comments start with ":" and are silently
+        # ignored by browser EventSource clients.
+        HEARTBEAT_SECS = 15
+        ticks_since_heartbeat = 0
         while True:
             job = job_store.get_job(job_id)
             if not job:
@@ -162,6 +170,12 @@ async def stream_job_progress(
             if progress_data != last_progress:
                 yield f"data: {json.dumps(progress_data)}\n\n"
                 last_progress = progress_data
+                ticks_since_heartbeat = 0
+            else:
+                ticks_since_heartbeat += 1
+                if ticks_since_heartbeat >= HEARTBEAT_SECS:
+                    yield ": heartbeat\n\n"
+                    ticks_since_heartbeat = 0
             if job["status"] in ["COMPLETED", "FAILED", "CANCELLED"]:
                 break
             await asyncio.sleep(1)

--- a/apps/web/app/api/matcher/jobs/[jobId]/stream/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/stream/route.ts
@@ -5,8 +5,21 @@
  */
 
 import { NextRequest } from "next/server";
+import { Agent } from "undici";
 
 const WORKFLOWS_API_URL = process.env.NEXT_PUBLIC_WORKFLOWS_API_URL || "http://localhost:2027";
+
+// Matcher rank stages can run 10+ minutes on CPU with no progress events
+// in between. Node 22 / undici default `bodyTimeout` is 5 minutes — the
+// SSE source emits heartbeats every 15s, but we still disable the body
+// timeout entirely (0 = no limit) so this proxy never gives up. Headers
+// timeout stays sane: if workflows-api can't even respond with headers
+// in 60s something is wrong.
+const sseDispatcher = new Agent({
+  bodyTimeout: 0,
+  headersTimeout: 60_000,
+  keepAliveTimeout: 60_000,
+});
 
 export async function GET(
   request: NextRequest,
@@ -19,6 +32,9 @@ export async function GET(
     headers: {
       Accept: "text/event-stream",
     },
+    // @ts-expect-error -- `dispatcher` is a Node fetch (undici) extension,
+    // not part of the standard fetch types but supported in Next.js 16.
+    dispatcher: sseDispatcher,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
Long matcher jobs (10+ min on CPU) were dying mid-stream with "UND_ERR_BODY_TIMEOUT" / "failed to pipe response" in Next.js. Two ends of the same problem:

1. workflows-api SSE only yielded when status changed. While rank_bu churned for minutes with no progress updates, the stream emitted zero bytes — any proxy in the path (undici, nginx, cloudflare) then enforced its own body-timeout and killed the connection. Now emits ":heartbeat\n\n" SSE comments every 15 s of silence; browser EventSource silently ignores comment frames.

2. Next.js's built-in fetch (Node 22 / undici) defaults bodyTimeout to 5 minutes. Heartbeats above make this less critical but a client that drops at 5 min is still a footgun. Pass a custom undici Agent with bodyTimeout: 0 (unlimited) and a 60 s headersTimeout for the SSE proxy fetch only.

Together: matcher jobs taking 20+ min stream cleanly all the way through to COMPLETED/FAILED.