### PR TITLE
fix(matcher web): create writable /app/data + named volume for result…

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -71,6 +71,11 @@ COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 
+# Writable storage for matcher result Excel cache (path.join(process.cwd(), "data")
+# in app/api/matcher/jobs/[jobId]/route.ts). /app is owned by root, so without
+# this the `nextjs` user gets EACCES when persisting the result file.
+RUN mkdir -p /app/data && chown -R nextjs:nodejs /app/data
+
 USER nextjs
 
 EXPOSE 3001

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -201,6 +201,10 @@ services:
       - "${WEB_PORT:-3001}:3001"
     volumes:
       - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+      # Persist matcher result Excel cache across container rebuilds.
+      # Path matches DATA_DIR = path.join(process.cwd(), "data") in
+      # apps/web/app/api/matcher/jobs/[jobId]/route.ts.
+      - web_data:/app/data
     depends_on:
       postgres:
         condition: service_healthy
@@ -215,3 +219,4 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  web_data:


### PR DESCRIPTION
… cache

The /api/matcher/jobs/[jobId]/route.ts handler caches the result Excel under DATA_DIR = path.join(process.cwd(), "data") so future downloads don't re-fetch from workflows-api. In the prod docker image /app is owned by root and /app/data does not exist, so the `nextjs` user got EACCES on mkdir and the persist step always failed (the job itself ran fine — only the local cache step blew up).

Two changes:
- apps/web/Dockerfile: mkdir + chown /app/data to nextjs:nodejs at build time, before USER nextjs takes effect.
- docker-compose.server.yml: mount a named `web_data` volume at /app/data so the cache survives `up -d --build web`.