### PR TITLE
feat(matcher): thread BYOK key via RunnableConfig instead of JobState

### DIFF
--- a/apps/langgraph/server/routes/matcher_jobs.py
+++ b/apps/langgraph/server/routes/matcher_jobs.py
@@ -35,29 +35,43 @@ def get_job_store() -> JobStore:
 
 
 async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data: list[dict]):
-    """Run match_job_graph in a worker thread (LOTUS / pandas blocks the loop)."""
+    """Run match_job_graph in a worker thread (LOTUS / pandas blocks the loop).
+
+    BYOK credentials (``api_key`` / ``api_base``) flow as a side-channel via
+    ``RunnableConfig.configurable.lm_config``. They MUST NOT enter the
+    JobState — putting them on the graph state leaks them into LangSmith
+    traces and any checkpoint store. See issue #152.
+    """
     store = JobStore()
     try:
 
-        class _Lm:
-            provider = req.model_provider
-            model = req.model_name
-            api_key = req.api_key
-            api_base = req.api_base
-
         class _Req:
+            """Non-secret, plain-data shim for graph state.
+
+            Holds only fields safe to log / checkpoint / trace. The LM
+            credentials live exclusively in the RunnableConfig below.
+            """
+
             queries = [q.model_dump() for q in req.queries]
             target_type = req.target_type.value
             top_k = req.top_k
             search_k = req.search_k
             include_reasons = req.include_reasons
-            lm = _Lm()
 
         graph_req = _Req()
         target_df = pd.DataFrame(target_data)
+        lm_config: dict = {
+            "provider": req.model_provider,
+            "model": req.model_name,
+            "api_key": req.api_key,
+        }
+        if req.api_base:
+            lm_config["api_base"] = req.api_base
+        run_config = {"configurable": {"lm_config": lm_config}}
         final = await asyncio.to_thread(
             match_job_graph.invoke,
             {"job_id": job_id, "target_df": target_df, "req": graph_req, "results_by_bu": {}},
+            run_config,
         )
         store.update_job(
             job_id,

--- a/apps/langgraph/tests/test_matcher_workflow.py
+++ b/apps/langgraph/tests/test_matcher_workflow.py
@@ -10,13 +10,16 @@ a live Redis.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 from server.matcher_types import MatchJobResponse
+from workflows.matcher._utils import redact_lm_config
 from workflows.matcher.job import (
+    JobState,
     assign_workers,
     orchestrator,
     rank_bu,
@@ -56,14 +59,25 @@ def _fake_optimized(bu: str):
 
 
 def _make_req(queries, target_type="publication"):
+    """Build a non-secret request shim. BYOK creds live in RunnableConfig."""
     req = MagicMock()
     req.queries = queries
     req.target_type = target_type
     req.top_k = 5
     req.search_k = 50
     req.include_reasons = True
-    req.lm = MagicMock(provider="openai", model="gpt-4o-mini", api_key="sk-t", api_base=None)
     return req
+
+
+def _make_config(api_key: str = "sk-test-key", **overrides):
+    """Build a RunnableConfig with the BYOK lm_config side-channel."""
+    lm_config = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "api_key": api_key,
+    }
+    lm_config.update(overrides)
+    return {"configurable": {"lm_config": lm_config}}
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +114,7 @@ def test_orchestrator_groups_queries_by_bu(monkeypatch):
     )
 
     state = {"job_id": job_id, "target_df": pd.DataFrame(), "req": req, "results_by_bu": {}}
-    out = orchestrator(state)
+    out = orchestrator(state, _make_config())
 
     assert set(out["queries_by_bu"].keys()) == {"BU_A", "BU_B"}
     assert out["queries_by_bu"]["BU_A"] == ["q1", "q1b"]
@@ -109,6 +123,64 @@ def test_orchestrator_groups_queries_by_bu(monkeypatch):
     job = JobStore().get_job(job_id)
     assert job["status"] == "PROCESSING"
     assert job["progress"] == 30
+
+
+def test_orchestrator_passes_lm_config_to_optimizer(monkeypatch):
+    """QueryOptimizer must be instantiated with creds from RunnableConfig, not state."""
+    captured: dict = {}
+
+    def fake_qo_ctor(**kwargs):
+        captured.update(kwargs)
+        instance = MagicMock()
+        instance.optimize_queries = MagicMock(side_effect=lambda **kw: _fake_optimized(kw["bu"]))
+        return instance
+
+    monkeypatch.setattr("workflows.matcher.job.QueryOptimizer", fake_qo_ctor)
+
+    req = _make_req([{"bu": "BU_A", "query": "q1"}])
+    job_id = JobStore().create_job(
+        user_id="u",
+        instance_id="i",
+        target_type="publication",
+        top_k=5,
+        search_k=50,
+        include_reasons=True,
+        query_data=req.queries,
+        query_count=1,
+        target_data=[],
+        model_provider="google",
+        model_name="gemini-2.5-flash",
+    )
+    state = {"job_id": job_id, "target_df": pd.DataFrame(), "req": req, "results_by_bu": {}}
+    config = _make_config(
+        provider="google", model="gemini-2.5-flash", api_key="byok-secret-123"
+    )
+    orchestrator(state, config)
+
+    assert captured.get("model_provider") == "google"
+    assert captured.get("model_name") == "gemini-2.5-flash"
+    assert captured.get("api_key") == "byok-secret-123"
+
+
+def test_orchestrator_raises_when_lm_config_missing():
+    """Without a BYOK lm_config the matcher cannot run; surface immediately."""
+    req = _make_req([{"bu": "BU_A", "query": "q1"}])
+    job_id = JobStore().create_job(
+        user_id="u",
+        instance_id="i",
+        target_type="publication",
+        top_k=5,
+        search_k=50,
+        include_reasons=True,
+        query_data=req.queries,
+        query_count=1,
+        target_data=[],
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+    )
+    state = {"job_id": job_id, "target_df": pd.DataFrame(), "req": req, "results_by_bu": {}}
+    with pytest.raises(RuntimeError, match="BYOK lm_config"):
+        orchestrator(state, {"configurable": {}})
 
 
 def test_assign_workers_emits_one_send_per_bu():
@@ -122,6 +194,24 @@ def test_assign_workers_emits_one_send_per_bu():
     assert len(sends) == 2
     assert {s.node for s in sends} == {"rank_bu"}
     assert {s.arg["bu"] for s in sends} == {"BU_A", "BU_B"}
+    # Sends must NOT carry the BYOK key — it flows via RunnableConfig.
+    for s in sends:
+        assert "api_key" not in s.arg
+        assert "lm_config" not in s.arg
+
+
+def test_assign_workers_does_not_leak_secrets_in_send_args():
+    """Regression: BYOK keys must never live in Send args (the arg gets logged)."""
+    state = {
+        "target_df": pd.DataFrame(),
+        "req": _make_req([{"bu": "BU_A", "query": "q1"}]),
+        "optimized": {"BU_A": _fake_optimized("BU_A")},
+        "index_dir": "/tmp/x",
+    }
+    sends = assign_workers(state)
+    payload = repr(sends)
+    assert "sk-test-key" not in payload
+    assert "api_key" not in payload
 
 
 def test_rank_bu_invokes_lotus_and_returns_results_by_bu(monkeypatch):
@@ -137,12 +227,58 @@ def test_rank_bu_invokes_lotus_and_returns_results_by_bu(monkeypatch):
         "req": _make_req([{"bu": "BU_X", "query": "q"}]),
         "index_dir": "/tmp/x",
     }
-    out = rank_bu(ws)
+    out = rank_bu(ws, _make_config())
     assert "results_by_bu" in out
     assert "BU_X" in out["results_by_bu"]
     df = out["results_by_bu"]["BU_X"]
     assert "bu" in df.columns
     assert "rank" in df.columns
+
+
+def test_rank_bu_threads_lm_config_into_run_pipeline(monkeypatch):
+    """rank_bu reads BYOK creds from RunnableConfig and forwards to LotusMatcher."""
+    captured: dict = {}
+    fake_matcher = MagicMock()
+    fake_matcher.build_text_column = MagicMock(return_value=pd.DataFrame([{"id": 1}]))
+
+    def fake_run_pipeline(**kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame([{"id": 1, "title": "match"}])
+
+    fake_matcher.run_pipeline = fake_run_pipeline
+    monkeypatch.setattr("workflows.matcher.job.LotusMatcher", MagicMock(return_value=fake_matcher))
+
+    ws = {
+        "bu": "BU_X",
+        "optimized": _fake_optimized("BU_X"),
+        "target_df": pd.DataFrame([{"id": 1}]),
+        "req": _make_req([{"bu": "BU_X", "query": "q"}]),
+        "index_dir": "/tmp/x",
+    }
+    config = _make_config(
+        provider="deepseek",
+        model="deepseek-chat",
+        api_key="sk-byok-deepseek",
+        api_base="https://api.deepseek.com/v1",
+    )
+    rank_bu(ws, config)
+
+    assert captured.get("model_provider") == "deepseek"
+    assert captured.get("model_name") == "deepseek-chat"
+    assert captured.get("api_key") == "sk-byok-deepseek"
+    assert captured.get("api_base") == "https://api.deepseek.com/v1"
+
+
+def test_rank_bu_raises_when_lm_config_missing():
+    ws = {
+        "bu": "BU_X",
+        "optimized": _fake_optimized("BU_X"),
+        "target_df": pd.DataFrame([{"id": 1}]),
+        "req": _make_req([{"bu": "BU_X", "query": "q"}]),
+        "index_dir": "/tmp/x",
+    }
+    with pytest.raises(RuntimeError, match="BYOK lm_config"):
+        rank_bu(ws, {"configurable": {}})
 
 
 def test_synthesize_writes_excel_bytes_and_total_matches(monkeypatch):
@@ -173,9 +309,64 @@ def test_synthesize_writes_excel_bytes_and_total_matches(monkeypatch):
             "BU_B": pd.DataFrame([{"id": 3}]),
         },
     }
-    out = synthesize(state)
+    out = synthesize(state, _make_config())
     assert out["excel_bytes"] == b"BYTES"
     assert out["total_matches"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Security: BYOK key MUST NOT enter JobState
+# ---------------------------------------------------------------------------
+
+
+def test_jobstate_has_no_api_key_field():
+    """JobState (TypedDict) must not declare api_key/api_base — they live in RunnableConfig."""
+    fields = set(JobState.__annotations__.keys())
+    assert "api_key" not in fields
+    assert "api_base" not in fields
+
+
+def test_api_key_does_not_appear_in_job_state_repr():
+    """A populated state's repr (used by LangSmith / logs) must not contain the key."""
+    secret = "sk-must-not-leak-9c7a"
+    req = _make_req([{"bu": "BU_A", "query": "q"}])
+    state: JobState = {
+        "job_id": "abc",
+        "target_df": pd.DataFrame([{"id": 1}]),
+        "req": req,
+        "queries_by_bu": {"BU_A": ["q"]},
+        "optimized": {},
+        "results_by_bu": {},
+        "index_dir": "/tmp/x",
+    }
+    # Even with the secret available in the config, repr(state) cannot mention it.
+    config = _make_config(api_key=secret)
+    blob = repr(state) + json.dumps({k: str(v) for k, v in state.items()})
+    assert secret not in blob
+    # And configurable is what holds it — confirm so we know the test is meaningful.
+    assert config["configurable"]["lm_config"]["api_key"] == secret
+
+
+def test_redact_lm_config_scrubs_api_key():
+    cfg = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "api_key": "sk-very-secret",
+        "api_base": "https://api.example.com/v1",
+    }
+    redacted = redact_lm_config(cfg)
+    assert redacted["api_key"] == "<redacted>"
+    assert redacted["provider"] == "openai"
+    assert redacted["api_base"] == "https://api.example.com/v1"
+    # Ensure the original isn't mutated.
+    assert cfg["api_key"] == "sk-very-secret"
+
+
+def test_redact_lm_config_handles_missing_key():
+    assert redact_lm_config(None) == {}
+    assert redact_lm_config({}) == {}
+    cfg = {"provider": "openai", "model": "gpt-4o-mini"}
+    assert redact_lm_config(cfg) == cfg
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +415,77 @@ def test_create_job_rejects_empty_target_data(client, valid_job_request):
 def test_get_job_returns_404_for_unknown_id(client):
     response = client.get("/v1/workflows/matcher/jobs/no-such-job")
     assert response.status_code == 404
+
+
+def test_run_and_persist_passes_lm_config_via_runnable_config(monkeypatch):
+    """_run_and_persist must thread BYOK creds via RunnableConfig, never JobState.
+
+    Captures both args of match_job_graph.invoke and asserts:
+    - the state arg contains no api_key
+    - the config arg holds the BYOK key under configurable.lm_config
+    """
+    import asyncio
+
+    from server.matcher_types import (
+        CreateMatchJobRequest,
+        MatchTargetType,
+        ParsedQueryInput,
+    )
+    from server.routes import matcher_jobs
+
+    captured: dict = {}
+
+    def fake_invoke(state, config):
+        captured["state"] = state
+        captured["config"] = config
+        return {"excel_bytes": b"X", "total_matches": 0}
+
+    monkeypatch.setattr(
+        "server.routes.matcher_jobs.match_job_graph", MagicMock(invoke=fake_invoke)
+    )
+
+    secret_key = "sk-route-test-9b2a"
+    req = CreateMatchJobRequest(
+        user_id="u",
+        instance_id="i",
+        target_type=MatchTargetType.SESSION,
+        queries=[ParsedQueryInput(id="q1", bu="A", query="q", row_index=0)],
+        target_data=[{"id": "s1"}],
+        model_provider="deepseek",
+        model_name="deepseek-chat",
+        api_key=secret_key,
+        api_base="https://api.deepseek.com/v1",
+    )
+    job_id = JobStore().create_job(
+        user_id="u",
+        instance_id="i",
+        target_type="SESSION",
+        top_k=50,
+        search_k=350,
+        include_reasons=True,
+        query_data=[q.model_dump() for q in req.queries],
+        query_count=1,
+        target_data=req.target_data,
+        model_provider="deepseek",
+        model_name="deepseek-chat",
+    )
+
+    asyncio.run(matcher_jobs._run_and_persist(job_id, req, req.target_data))
+
+    state = captured["state"]
+    config = captured["config"]
+    # State must not carry the key.
+    assert "api_key" not in state
+    assert "api_base" not in state
+    graph_req = state["req"]
+    assert not hasattr(graph_req, "lm")
+    assert not hasattr(graph_req, "api_key")
+    # Config must.
+    lm_config = config["configurable"]["lm_config"]
+    assert lm_config["api_key"] == secret_key
+    assert lm_config["provider"] == "deepseek"
+    assert lm_config["model"] == "deepseek-chat"
+    assert lm_config["api_base"] == "https://api.deepseek.com/v1"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/langgraph/workflows/matcher/_utils.py
+++ b/apps/langgraph/workflows/matcher/_utils.py
@@ -1,0 +1,24 @@
+"""Internal utilities for the matcher workflow.
+
+Currently houses logging helpers that scrub BYOK secrets before they hit
+log lines or LangSmith traces. Keep this module dependency-light so it can
+be imported from any node without dragging in pandas / lotus / httpx.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def redact_lm_config(cfg: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a copy of an ``lm_config`` dict with the api_key replaced.
+
+    Used anywhere ``lm_config`` would otherwise be logged. Always copy so
+    callers can't accidentally mutate the original side-channel value.
+    """
+    if not cfg:
+        return {}
+    out = dict(cfg)
+    if out.get("api_key"):
+        out["api_key"] = "<redacted>"
+    return out

--- a/apps/langgraph/workflows/matcher/job.py
+++ b/apps/langgraph/workflows/matcher/job.py
@@ -6,6 +6,12 @@ synthesize assembles the master DataFrame and Excel bytes.
 
 JobStore writes are plain function calls inside nodes — NOT @task — to keep
 SSE polling deterministic.
+
+BYOK threading: the user's api_key / api_base never enter ``JobState``. The
+caller (server.routes.matcher_jobs._run_and_persist) puts them on a
+``RunnableConfig`` under ``configurable.lm_config``; nodes read it via the
+injected ``config`` parameter. This keeps the secret out of LangSmith
+traces, checkpoint stores, and any state.repr / pickle.
 """
 
 from __future__ import annotations
@@ -17,9 +23,11 @@ from datetime import datetime, timezone
 from typing import Annotated, Any, TypedDict
 
 import pandas as pd
+from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import Send
 
+from workflows.matcher._utils import redact_lm_config
 from workflows.matcher.excel_processor import ExcelProcessor
 from workflows.matcher.job_store import JobStore
 from workflows.matcher.lotus import LotusMatcher
@@ -34,6 +42,12 @@ def _merge_dict(left: dict, right: dict) -> dict:
 
 
 class JobState(TypedDict, total=False):
+    """LangGraph state for a matcher job.
+
+    Intentionally does NOT contain ``api_key`` / ``api_base``. BYOK
+    credentials flow via RunnableConfig.configurable["lm_config"].
+    """
+
     job_id: str
     target_df: pd.DataFrame
     req: Any
@@ -45,11 +59,34 @@ class JobState(TypedDict, total=False):
     index_dir: str
 
 
-def orchestrator(state: JobState) -> dict:
+def _lm_config_from(config: RunnableConfig) -> dict[str, Any]:
+    """Extract the BYOK ``lm_config`` dict from a RunnableConfig.
+
+    Raises if missing — the matcher cannot reach a third-party LM without
+    a BYOK key, so the caller is required to supply it.
+    """
+    configurable = (config or {}).get("configurable") or {}
+    lm_config = configurable.get("lm_config")
+    if not lm_config:
+        raise RuntimeError(
+            "Matcher workflow invoked without a BYOK lm_config on "
+            "RunnableConfig.configurable. The caller must pass "
+            "config={'configurable': {'lm_config': {...}}}."
+        )
+    return lm_config
+
+
+def orchestrator(state: JobState, config: RunnableConfig) -> dict:
     job_store.update_job(
         state["job_id"], status="PROCESSING", started_at=datetime.now(timezone.utc)
     )
     req = state["req"]
+    lm_config = _lm_config_from(config)
+    logger.info(
+        "Matcher orchestrator starting job %s with lm=%s",
+        state["job_id"],
+        redact_lm_config(lm_config),
+    )
     queries_by_bu: dict[str, list[str]] = defaultdict(list)
     for q in req.queries:
         bu = q.get("bu", "Unknown")
@@ -59,10 +96,10 @@ def orchestrator(state: JobState) -> dict:
     queries_by_bu = dict(queries_by_bu)
     optimizer = QueryOptimizer(
         excel_processor=ExcelProcessor(),
-        model_provider=req.lm.provider,
-        model_name=req.lm.model,
-        api_key=req.lm.api_key,
-        api_base=req.lm.api_base,
+        model_provider=lm_config.get("provider"),
+        model_name=lm_config.get("model"),
+        api_key=lm_config.get("api_key"),
+        api_base=lm_config.get("api_base"),
     )
     optimized: dict[str, Any] = {}
     total_bus = max(len(queries_by_bu), 1)
@@ -85,7 +122,13 @@ def orchestrator(state: JobState) -> dict:
 
 
 def assign_workers(state: JobState) -> list[Send]:
-    """Send one rank_bu invocation per BU. Per ref doc §Creating workers in LangGraph."""
+    """Send one rank_bu invocation per BU. Per ref doc §Creating workers in LangGraph.
+
+    Note: RunnableConfig (and ``configurable.lm_config``) propagates through
+    Send dispatch automatically — each rank_bu invocation gets the same
+    config that orchestrator received. No need to thread the LM creds via
+    the Send arg.
+    """
     return [
         Send(
             "rank_bu",
@@ -101,8 +144,9 @@ def assign_workers(state: JobState) -> list[Send]:
     ]
 
 
-def rank_bu(ws: dict) -> dict:
+def rank_bu(ws: dict, config: RunnableConfig) -> dict:
     """Worker — runs LOTUS pipeline for one BU. Writes one entry into results_by_bu."""
+    lm_config = _lm_config_from(config)
     matcher = LotusMatcher()
     target_df = matcher.build_text_column(ws["target_df"], ws["req"].target_type)
     matches_df = matcher.run_pipeline(
@@ -114,10 +158,10 @@ def rank_bu(ws: dict) -> dict:
         include_reasons=ws["req"].include_reasons,
         index_dir=ws["index_dir"],
         progress_callback=lambda *_: None,
-        model_provider=ws["req"].lm.provider,
-        model_name=ws["req"].lm.model,
-        api_key=ws["req"].lm.api_key,
-        api_base=ws["req"].lm.api_base,
+        model_provider=lm_config.get("provider"),
+        model_name=lm_config.get("model"),
+        api_key=lm_config.get("api_key"),
+        api_base=lm_config.get("api_base"),
     )
     matches_df.insert(0, "bu", ws["bu"])
     matches_df.insert(0, "rank", range(1, len(matches_df) + 1))
@@ -127,7 +171,11 @@ def rank_bu(ws: dict) -> dict:
     return {"results_by_bu": {ws["bu"]: matches_df}}
 
 
-def synthesize(state: JobState) -> dict:
+def synthesize(state: JobState, config: RunnableConfig) -> dict:
+    # config is currently unused in synthesize, but accepted so future
+    # nodes in this position can reach the BYOK side-channel without a
+    # signature break.
+    _ = config
     job_store.update_job(state["job_id"], progress=85, error_message="Creating result file...")
     master = _build_master(state["target_df"], state["results_by_bu"], state["req"].include_reasons)
     excel_bytes = ExcelProcessor().create_result_excel(


### PR DESCRIPTION
Closes #152

## Summary

User-supplied BYOK API keys were threaded through `JobState` and a duck-typed `_Lm` shim on `req`, which meant any user's OpenAI / DeepSeek / Gemini key could land in cleartext in LangSmith traces, the LangGraph checkpoint store, and any process memory dump or log line that printed the state.

This PR moves BYOK credentials to a side-channel that is never serialized into graph state, never checkpointed, and never visible in traces.

- `_run_and_persist` builds `lm_config` and passes it via `RunnableConfig.configurable.lm_config` to `match_job_graph.invoke` (no more `_Lm` shim).
- `orchestrator` / `rank_bu` / `synthesize` accept `config: RunnableConfig` and read BYOK creds from there. `RunnableConfig` propagates through `Send` dispatch automatically — workers don't need the creds on their state arg.
- `JobState` no longer declares `api_key` / `api_base`.
- New `workflows/matcher/_utils.redact_lm_config` scrubs the key before any log / trace emission, and is used in the orchestrator's startup log line.

## Acceptance criteria (from #152)

- [x] `JobState` no longer contains an `api_key` field — verified by `test_jobstate_has_no_api_key_field`.
- [x] `lm_config` reaches `_rank_via_semops` and the optimizer via `RunnableConfig`, not state — verified by `test_orchestrator_passes_lm_config_to_optimizer` and `test_rank_bu_threads_lm_config_into_run_pipeline`.
- [x] No BYOK substring leaks into `Send` args — `test_assign_workers_does_not_leak_secrets_in_send_args`.
- [x] State `repr` does not contain the key — `test_api_key_does_not_appear_in_job_state_repr`.

## Out of scope

Per issue #152: no callback work (#150), no `LotusMatcher` / `QueryOptimizer` collapse (#154), no `_build_master` changes (#153), no `apps/semops` changes (#151). Only minimal touch on `matcher_jobs.py:_run_and_persist` so this stays mergeable next to `feat/matcher-state-callback`.

## Test plan

- [x] `pytest tests/test_matcher_workflow.py -v` — 19 / 19 pass (10 existing + 9 new BYOK-side-channel tests).
- [x] Full `tests/` suite re-run — only pre-existing hub-agent failures (`test_hub_all_frontend_tool_calls_terminates_loop`, `test_hub_mixed_frontend_and_backend`) remain; they reproduce on `origin/agent-dev` without this patch and are unrelated to the matcher.
- [ ] Manual: run a matcher job with `LANGSMITH_API_KEY` set and confirm the trace contains no `sk-...` substring (deferred to deploy validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)