### PR TITLE
fix(matcher): _build_master schema clamp + Int64 rank casting (#153)

### DIFF
--- a/apps/langgraph/tests/test_matcher_workflow.py
+++ b/apps/langgraph/tests/test_matcher_workflow.py
@@ -17,6 +17,7 @@ import pytest
 from fastapi.testclient import TestClient
 from server.matcher_types import MatchJobResponse
 from workflows.matcher.job import (
+    _build_master,
     assign_workers,
     orchestrator,
     rank_bu,
@@ -176,6 +177,63 @@ def test_synthesize_writes_excel_bytes_and_total_matches(monkeypatch):
     out = synthesize(state)
     assert out["excel_bytes"] == b"BYTES"
     assert out["total_matches"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _build_master — schema-clamp + Int64 rank casting (issue #153)
+# ---------------------------------------------------------------------------
+
+
+def test_build_master_casts_unmatched_rank_to_nullable_int():
+    """master[bu] should be Int64 (not float) so Excel doesn't show 1.0."""
+    target_df = pd.DataFrame(
+        [
+            {"id": 1, "title": "row 1"},
+            {"id": 2, "title": "row 2"},
+            {"id": 3, "title": "row 3"},
+        ]
+    )
+    # BU returns only 2 of the 3 target rows — row id=3 will be unmatched.
+    results_by_bu = {
+        "BU_A": pd.DataFrame(
+            [
+                {"id": 1, "rank": 1, "title": "row 1"},
+                {"id": 2, "rank": 2, "title": "row 2"},
+            ]
+        )
+    }
+
+    master = _build_master(target_df, results_by_bu, include_reasons=False)
+
+    assert master["BU_A"].dtype == pd.Int64Dtype(), (
+        f"expected Int64, got {master['BU_A'].dtype!r}"
+    )
+    # Matched rows keep int values (no float upcast).
+    assert master.loc[master["title"] == "row 1", "BU_A"].iloc[0] == 1
+    assert master.loc[master["title"] == "row 2", "BU_A"].iloc[0] == 2
+    # Unmatched row is pd.NA (nullable-int missing), not float NaN.
+    unmatched = master.loc[master["title"] == "row 3", "BU_A"].iloc[0]
+    assert unmatched is pd.NA
+    assert not (isinstance(unmatched, float) and unmatched != unmatched)
+
+
+def test_build_master_rejects_mixed_id_columns():
+    """If two BUs disagree on id column, raise loudly with both BU names."""
+    target_df = pd.DataFrame([{"id": 1, "title": "row 1"}])
+    results_by_bu = {
+        "BU_A": pd.DataFrame([{"id": 1, "rank": 1, "title": "row 1"}]),
+        # BU_B intentionally lacks 'id' — its identity column is 'title'.
+        "BU_B": pd.DataFrame([{"title": "row 1", "rank": 1}]),
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        _build_master(target_df, results_by_bu, include_reasons=False)
+
+    msg = str(excinfo.value)
+    assert "BU_A" in msg
+    assert "BU_B" in msg
+    assert "id" in msg
+    assert "title" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/apps/langgraph/workflows/matcher/job.py
+++ b/apps/langgraph/workflows/matcher/job.py
@@ -162,14 +162,31 @@ def _enriched(queries: list[dict], optimized: dict[str, Any]) -> list[dict]:
 def _build_master(
     target_df: pd.DataFrame, results_by_bu: dict[str, pd.DataFrame], include_reasons: bool
 ) -> pd.DataFrame:
+    # Validate identity-column consistency across BU result frames.
+    # If two BUs disagree (one returns 'id', another only 'title'), joins
+    # would silently key on different columns and emit wrong rows.
+    id_columns = {
+        bu: ("id" if "id" in df.columns else "title") for bu, df in results_by_bu.items()
+    }
+    distinct = set(id_columns.values())
+    if len(distinct) > 1:
+        raise ValueError(
+            f"BU result DataFrames have inconsistent identity columns: {id_columns}. "
+            f"All BUs must agree on either 'id' or 'title' as the join key."
+        )
+    # Capture id_col once and use everywhere — avoids order coupling between
+    # `master.drop(columns=["id"])` and reason aggregation.
+    id_col = next(iter(distinct), "id")
+
     master = target_df.drop(columns=["match_text"], errors="ignore").copy()
     bu_names = list(results_by_bu.keys())
     for bu in bu_names:
         bu_df = results_by_bu[bu]
-        id_col = "id" if "id" in bu_df.columns else ("title" if "title" in bu_df.columns else None)
-        if id_col and id_col in master.columns:
+        if id_col in bu_df.columns and id_col in master.columns:
             rank_map = dict(zip(bu_df[id_col], bu_df["rank"]))
-            master[bu] = master[id_col].map(rank_map)
+            # Cast to nullable Int64 so unmatched rows render as blank in
+            # Excel instead of `1.0, 2.0, NaN` (float upcast on .map miss).
+            master[bu] = master[id_col].map(rank_map).astype("Int64")
         else:
             master[bu] = ""
     if include_reasons and any(
@@ -180,15 +197,13 @@ def _build_master(
             df = results_by_bu[bu]
             if "recommendation_reason" not in df.columns:
                 continue
-            key = "id" if "id" in df.columns else "title"
-            if key in df.columns:
-                reason_maps[bu] = dict(zip(df[key], df["recommendation_reason"]))
-        if reason_maps:
-            id_key = "id" if "id" in master.columns else "title"
+            if id_col in df.columns:
+                reason_maps[bu] = dict(zip(df[id_col], df["recommendation_reason"]))
+        if reason_maps and id_col in master.columns:
 
             def agg(row):
                 parts = []
-                k = row[id_key]
+                k = row[id_col]
                 for bu, m in reason_maps.items():
                     r = m.get(k)
                     if r and str(r).strip():


### PR DESCRIPTION
Three NaN-class data-correctness fixes in `_build_master`:

1. Cast `master[bu] = master[id_col].map(rank_map)` to nullable `Int64` so unmatched rows render as blank in Excel instead of `1.0, 2.0, NaN` (the float upcast on `.map` miss).

2. Validate identity-column consistency across BU result frames at the top of `_build_master`. If two BUs disagree (one returns 'id', another only 'title'), raise `ValueError` with both BU names instead of silently joining on different keys per BU.

3. Capture `id_col` once and use it consistently for the rank join, the reason aggregation, and the inner agg closure — removes the order coupling between the trailing `master.drop(columns=["id"])` and the reason aggregation's `id_key` resolution.

Adds two regression tests:
- `test_build_master_casts_unmatched_rank_to_nullable_int` — checks the dtype is `pd.Int64Dtype()` and unmatched rows are `pd.NA`.
- `test_build_master_rejects_mixed_id_columns` — checks the ValueError mentions both BU names and both column names.

Closes #153