### PR TITLE
feat(matcher): persist job state via workflows-api callback (#150)

### DIFF
--- a/apps/langgraph/server/routes/matcher_jobs.py
+++ b/apps/langgraph/server/routes/matcher_jobs.py
@@ -35,26 +35,38 @@ def get_job_store() -> JobStore:
 
 
 async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data: list[dict]):
-    """Run match_job_graph in a worker thread (LOTUS / pandas blocks the loop)."""
+    """Run match_job_graph in a worker thread (LOTUS / pandas blocks the loop).
+
+    Terminal-status invariant: this function GUARANTEES that the job ends in
+    one of {COMPLETED, FAILED, CANCELLED} before returning. Without this, a
+    SIGTERM mid-rank or an unexpected exception would leave the row stuck at
+    PROCESSING forever in Postgres.
+
+    asyncio.CancelledError does NOT inherit from Exception in Python 3.8+,
+    so it has its own handler that marks the job FAILED with
+    error_message="cancelled" and re-raises (must propagate to honour the
+    cancellation contract).
+    """
     store = JobStore()
+
+    class _Lm:
+        provider = req.model_provider
+        model = req.model_name
+        api_key = req.api_key
+        api_base = req.api_base
+
+    class _Req:
+        queries = [q.model_dump() for q in req.queries]
+        target_type = req.target_type.value
+        top_k = req.top_k
+        search_k = req.search_k
+        include_reasons = req.include_reasons
+        lm = _Lm()
+
+    graph_req = _Req()
+    target_df = pd.DataFrame(target_data)
+
     try:
-
-        class _Lm:
-            provider = req.model_provider
-            model = req.model_name
-            api_key = req.api_key
-            api_base = req.api_base
-
-        class _Req:
-            queries = [q.model_dump() for q in req.queries]
-            target_type = req.target_type.value
-            top_k = req.top_k
-            search_k = req.search_k
-            include_reasons = req.include_reasons
-            lm = _Lm()
-
-        graph_req = _Req()
-        target_df = pd.DataFrame(target_data)
         final = await asyncio.to_thread(
             match_job_graph.invoke,
             {"job_id": job_id, "target_df": target_df, "req": graph_req, "results_by_bu": {}},
@@ -68,11 +80,42 @@ async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data:
             completed_at=datetime.now(timezone.utc),
             error_message=None,
         )
+    except asyncio.CancelledError:
+        # Cancellation MUST propagate (asyncio contract), but we still need
+        # to flush a terminal status to the row first. CancelledError doesn't
+        # derive from Exception in 3.8+, so the broader except below misses it.
+        logger.warning(f"Job {job_id} cancelled mid-run")
+        store.update_job(
+            job_id,
+            status="FAILED",
+            error_message="cancelled",
+            completed_at=datetime.now(timezone.utc),
+        )
+        raise
     except Exception as exc:  # noqa: BLE001
         logger.exception(f"Job {job_id} failed: {exc}")
         store.update_job(
-            job_id, status="FAILED", error_message=str(exc), completed_at=datetime.now(timezone.utc)
+            job_id,
+            status="FAILED",
+            error_message=str(exc),
+            completed_at=datetime.now(timezone.utc),
         )
+    finally:
+        # Belt-and-braces: if some path above failed to write a terminal
+        # status (e.g. exception inside an exception handler, sync bug),
+        # force one here so the row never lingers at PROCESSING.
+        job = store.get_job(job_id)
+        if job and job.get("status") not in {"COMPLETED", "FAILED", "CANCELLED"}:
+            logger.warning(
+                f"Job {job_id} exited with non-terminal status "
+                f"{job.get('status')!r} — forcing FAILED"
+            )
+            store.update_job(
+                job_id,
+                status="FAILED",
+                error_message=job.get("error_message") or "unknown error",
+                completed_at=datetime.now(timezone.utc),
+            )
 
 
 @router.post("/jobs", response_model=MatchJobResponse)

--- a/apps/langgraph/tests/test_matcher_workflow.py
+++ b/apps/langgraph/tests/test_matcher_workflow.py
@@ -10,6 +10,7 @@ a live Redis.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
@@ -287,3 +288,199 @@ def test_run_pipeline_replaces_nan_with_none_before_serialization(monkeypatch):
             ), f"NaN leaked in candidate field {key!r}: {row!r}"
 
     json.dumps(candidates, allow_nan=False)
+
+
+# ---------------------------------------------------------------------------
+# Terminal-status invariant in _run_and_persist
+# ---------------------------------------------------------------------------
+
+
+def _seed_job(req_overrides: dict | None = None) -> tuple[str, MagicMock]:
+    """Seed a JobStore row + mock CreateMatchJobRequest sufficient for
+    _run_and_persist to consume.
+    """
+    job_id = JobStore().create_job(
+        user_id="u",
+        instance_id="i",
+        target_type="publication",
+        top_k=5,
+        search_k=50,
+        include_reasons=True,
+        query_data=[],
+        query_count=0,
+        target_data=[],
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+    )
+    req = MagicMock()
+    req.queries = []
+    req.target_type = MagicMock(value="publication")
+    req.top_k = 5
+    req.search_k = 50
+    req.include_reasons = True
+    req.model_provider = "openai"
+    req.model_name = "gpt-4o-mini"
+    req.api_key = "sk-test"
+    req.api_base = None
+    if req_overrides:
+        for k, v in req_overrides.items():
+            setattr(req, k, v)
+    return job_id, req
+
+
+def test_run_and_persist_marks_failed_on_cancellation(monkeypatch):
+    """SIGTERM mid-rank → row must end FAILED with error_message='cancelled'.
+
+    Reproduces the production symptom: the workflows-api container gets
+    redeployed mid-job (asyncio cancels the BackgroundTask) and the row
+    used to be left at PROCESSING forever.
+    """
+    from server.routes import matcher_jobs as routes
+
+    job_id, req = _seed_job()
+
+    async def _raise_cancelled(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(routes.asyncio, "to_thread", _raise_cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(routes._run_and_persist(job_id, req, []))
+
+    job = JobStore().get_job(job_id)
+    assert job is not None
+    assert job["status"] == "FAILED"
+    assert job["error_message"] == "cancelled"
+    assert job["completed_at"] is not None
+
+
+def test_run_and_persist_marks_failed_on_exception(monkeypatch):
+    """Generic exception in the worker thread → row must end FAILED with the
+    exception's message. No re-raise — BackgroundTasks shouldn't crash the
+    app event loop on a per-job failure.
+    """
+    from server.routes import matcher_jobs as routes
+
+    job_id, req = _seed_job()
+
+    async def _raise_value_error(*_args, **_kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(routes.asyncio, "to_thread", _raise_value_error)
+
+    # Should NOT raise — generic exceptions are swallowed by design.
+    asyncio.run(routes._run_and_persist(job_id, req, []))
+
+    job = JobStore().get_job(job_id)
+    assert job is not None
+    assert job["status"] == "FAILED"
+    assert job["error_message"] == "boom"
+    assert job["completed_at"] is not None
+
+
+def test_run_and_persist_marks_completed_on_success(monkeypatch):
+    """Happy path stays happy — graph returns excel_bytes, row goes COMPLETED."""
+    from server.routes import matcher_jobs as routes
+
+    job_id, req = _seed_job()
+
+    async def _ok(*_args, **_kwargs):
+        return {"excel_bytes": b"BYTES", "total_matches": 7}
+
+    monkeypatch.setattr(routes.asyncio, "to_thread", _ok)
+
+    asyncio.run(routes._run_and_persist(job_id, req, []))
+
+    job = JobStore().get_job(job_id)
+    assert job is not None
+    assert job["status"] == "COMPLETED"
+    assert job["progress"] == 100
+    assert job["match_count"] == 7
+    assert job["error_message"] is None
+
+
+# ---------------------------------------------------------------------------
+# JobStore status-change callback
+# ---------------------------------------------------------------------------
+
+
+def test_update_job_fires_callback_on_status_transition(monkeypatch):
+    """Genuine status flip (PENDING → PROCESSING) triggers a callback POST."""
+    from workflows.matcher import job_store as js_module
+
+    captured: dict = {}
+
+    def _fake_post(job_id: str, payload: dict) -> None:
+        captured["job_id"] = job_id
+        captured["payload"] = payload
+
+    monkeypatch.setattr(js_module, "_post_status_callback", _fake_post)
+
+    store = JobStore()
+    job_id = store.create_job(
+        user_id="u",
+        instance_id="i",
+        target_type="publication",
+        top_k=5,
+        search_k=50,
+        include_reasons=True,
+        query_data=[],
+        query_count=0,
+        target_data=[],
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+    )
+
+    store.update_job(job_id, status="PROCESSING", progress=10)
+
+    assert captured["job_id"] == job_id
+    assert captured["payload"]["status"] == "PROCESSING"
+    assert captured["payload"]["progress"] == 10
+
+
+def test_update_job_does_not_fire_callback_on_progress_only(monkeypatch):
+    """Progress-only ticks don't trigger the callback — too noisy and the SSE
+    stream already covers them.
+    """
+    from workflows.matcher import job_store as js_module
+
+    calls: list = []
+
+    def _fake_post(job_id: str, payload: dict) -> None:
+        calls.append((job_id, payload))
+
+    monkeypatch.setattr(js_module, "_post_status_callback", _fake_post)
+
+    store = JobStore()
+    job_id = store.create_job(
+        user_id="u",
+        instance_id="i",
+        target_type="publication",
+        top_k=5,
+        search_k=50,
+        include_reasons=True,
+        query_data=[],
+        query_count=0,
+        target_data=[],
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+    )
+
+    # Move to PROCESSING (one callback expected).
+    store.update_job(job_id, status="PROCESSING")
+    assert len(calls) == 1
+
+    # Several progress-only ticks — no extra callbacks.
+    store.update_job(job_id, progress=20)
+    store.update_job(job_id, progress=50)
+    store.update_job(job_id, progress=80)
+    assert len(calls) == 1
+
+    # Setting status to its current value is a no-op (no transition).
+    store.update_job(job_id, status="PROCESSING", progress=85)
+    assert len(calls) == 1
+
+    # Terminal flip fires another callback.
+    store.update_job(job_id, status="COMPLETED", progress=100)
+    assert len(calls) == 2
+    assert calls[1][1]["status"] == "COMPLETED"

--- a/apps/langgraph/workflows/matcher/job_store.py
+++ b/apps/langgraph/workflows/matcher/job_store.py
@@ -3,15 +3,92 @@ Job Store
 
 Simple in-memory storage for match jobs.
 For production, consider using Redis or database.
+
+When the in-memory `status` field of a job actually changes (transition or
+terminal flip — not progress ticks), `update_job` fires a best-effort
+callback to the Next.js side so Postgres mirrors the workflows-api state
+without depending on the user holding open a stream. Callback failure is
+logged but never raised; the matcher continues on its own.
 """
 
+import json
 import logging
+import os
 import threading
+import urllib.error
+import urllib.request
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+_CALLBACK_TIMEOUT_S = 5.0
+
+
+def _post_status_callback(job_id: str, payload: dict[str, Any]) -> None:
+    """POST a status update to the Next.js internal route.
+
+    Synchronous urllib call — JobStore.update_job is invoked from worker
+    threads (asyncio.to_thread) and from inside the LangGraph node bodies,
+    so we cannot rely on an event loop being available. urllib in stdlib
+    avoids the httpx async/sync split entirely.
+
+    Best-effort: any error logs a warning and returns. Callback failure
+    must NOT fail the matcher.
+    """
+    base = os.getenv("SPARKFLOW_API_URL")
+    token = os.getenv("INTERNAL_CALLBACK_TOKEN")
+    if not base or not token:
+        logger.debug(
+            "[matcher callback] SPARKFLOW_API_URL or INTERNAL_CALLBACK_TOKEN unset — skipping"
+        )
+        return
+
+    url = f"{base.rstrip('/')}/api/internal/matcher/jobs/{job_id}"
+    body = json.dumps(_jsonify(payload)).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+            # Sent for compat with existing X-Internal-Token consumers.
+            "X-Internal-Token": token,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_CALLBACK_TIMEOUT_S) as resp:
+            if resp.status >= 400:
+                logger.warning(
+                    "[matcher callback] %s → HTTP %s for job %s", url, resp.status, job_id
+                )
+    except urllib.error.HTTPError as exc:
+        logger.warning(
+            "[matcher callback] HTTP %s posting status for job %s: %s",
+            exc.code,
+            job_id,
+            exc.reason,
+        )
+    except (urllib.error.URLError, OSError) as exc:
+        logger.warning("[matcher callback] network error for job %s: %s", job_id, exc)
+    except Exception as exc:  # noqa: BLE001 — must never bubble
+        logger.warning(
+            "[matcher callback] unexpected error for job %s: %s", job_id, exc, exc_info=True
+        )
+
+
+def _jsonify(payload: dict[str, Any]) -> dict[str, Any]:
+    """Coerce datetimes etc. to JSON-friendly primitives."""
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if isinstance(v, datetime):
+            out[k] = v.isoformat()
+        else:
+            out[k] = v
+    return out
 
 
 class JobStore:
@@ -81,11 +158,41 @@ class JobStore:
             return self._jobs.get(job_id)
 
     def update_job(self, job_id: str, **kwargs) -> None:
-        """Update job fields."""
+        """Update job fields.
+
+        Side effect: when `status` is in the update and the value actually
+        differs from the stored status (genuine transition, not idle re-set),
+        fire a best-effort callback to Next.js so Postgres mirrors the new
+        terminal/intermediate state. Progress-only ticks don't trigger the
+        callback — too noisy and the SSE stream already covers them.
+        """
+        status_changed = False
+        callback_payload: dict[str, Any] = {}
+
         with self._job_lock:
-            if job_id in self._jobs:
-                self._jobs[job_id].update(kwargs)
-                self._jobs[job_id]["updated_at"] = datetime.now(timezone.utc)
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+
+            new_status = kwargs.get("status")
+            if new_status is not None and new_status != job.get("status"):
+                status_changed = True
+
+            job.update(kwargs)
+            job["updated_at"] = datetime.now(timezone.utc)
+
+            if status_changed:
+                callback_payload = {
+                    "status": job["status"],
+                    "progress": job.get("progress", 0),
+                    "match_count": job.get("match_count", 0),
+                    "error_message": job.get("error_message"),
+                    "started_at": job.get("started_at"),
+                    "completed_at": job.get("completed_at"),
+                }
+
+        if status_changed:
+            _post_status_callback(job_id, callback_payload)
 
     def get_result_data(self, job_id: str) -> Optional[bytes]:
         """Get result Excel bytes for a job."""

--- a/apps/web/app/api/internal/matcher/jobs/[id]/route.ts
+++ b/apps/web/app/api/internal/matcher/jobs/[id]/route.ts
@@ -1,0 +1,154 @@
+/**
+ * POST /api/internal/matcher/jobs/[id]
+ *
+ * Internal callback endpoint — called by the workflows-api whenever a
+ * MatchJob's status flips. Protected by a shared-secret bearer token
+ * (INTERNAL_CALLBACK_TOKEN) NOT NextAuth.
+ *
+ * Body is snake_case to match the workflows-api convention; coerced to
+ * camelCase before writing to Prisma.
+ *
+ * Idempotent: if the row's current status is already terminal
+ * (COMPLETED | FAILED | CANCELLED) a callback that would un-terminate it
+ * is ignored — guards against an out-of-order callback re-opening a job.
+ *
+ * Fail-closed: if INTERNAL_CALLBACK_TOKEN is empty/undefined, returns 500.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { MatchJobStatus, Prisma } from "@prisma/client";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+interface CallbackBody {
+  status?: string;
+  progress?: number;
+  error_message?: string | null;
+  match_count?: number;
+  started_at?: string;
+  completed_at?: string;
+}
+
+const TERMINAL_STATUSES: ReadonlySet<MatchJobStatus> = new Set([
+  MatchJobStatus.COMPLETED,
+  MatchJobStatus.FAILED,
+  MatchJobStatus.CANCELLED,
+]);
+
+const ALL_STATUSES: ReadonlySet<MatchJobStatus> = new Set([
+  MatchJobStatus.PENDING,
+  MatchJobStatus.PROCESSING,
+  MatchJobStatus.COMPLETED,
+  MatchJobStatus.FAILED,
+  MatchJobStatus.CANCELLED,
+]);
+
+function isMatchJobStatus(value: unknown): value is MatchJobStatus {
+  return typeof value === "string" && ALL_STATUSES.has(value as MatchJobStatus);
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+function checkAuth(request: NextRequest): NextResponse | null {
+  const token = process.env.INTERNAL_CALLBACK_TOKEN;
+  if (!token) {
+    return NextResponse.json({ error: "INTERNAL_CALLBACK_TOKEN not configured" }, { status: 500 });
+  }
+
+  // Accept either `Authorization: Bearer <token>` (the new spec) or
+  // `X-Internal-Token: <token>` (existing convention, for compat).
+  const authHeader = request.headers.get("authorization") ?? "";
+  const bearerToken = authHeader.toLowerCase().startsWith("bearer ")
+    ? authHeader.slice("bearer ".length).trim()
+    : "";
+  const xInternalToken = request.headers.get("x-internal-token") ?? "";
+
+  if (bearerToken !== token && xInternalToken !== token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const authError = checkAuth(request);
+  if (authError) return authError;
+
+  let body: CallbackBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { id } = await params;
+
+  // Coerce snake_case → camelCase, validate fields.
+  const data: Prisma.MatchJobUpdateInput = {};
+
+  if (body.status !== undefined) {
+    if (!isMatchJobStatus(body.status)) {
+      return NextResponse.json(
+        { error: `Invalid status value: "${body.status}"` },
+        { status: 400 },
+      );
+    }
+    data.status = body.status;
+  }
+
+  if (body.progress !== undefined) {
+    if (typeof body.progress !== "number" || !Number.isFinite(body.progress)) {
+      return NextResponse.json({ error: "Invalid progress value" }, { status: 400 });
+    }
+    data.progress = body.progress;
+  }
+
+  if (body.match_count !== undefined) {
+    if (typeof body.match_count !== "number" || !Number.isFinite(body.match_count)) {
+      return NextResponse.json({ error: "Invalid match_count value" }, { status: 400 });
+    }
+    data.matchCount = body.match_count;
+  }
+
+  if (body.error_message !== undefined) {
+    data.errorMessage = body.error_message;
+  }
+
+  const startedAt = parseDate(body.started_at);
+  if (startedAt) data.startedAt = startedAt;
+
+  const completedAt = parseDate(body.completed_at);
+  if (completedAt) data.completedAt = completedAt;
+
+  // Idempotency: if the current row is already in a terminal state and the
+  // incoming status would un-terminate it (back to PENDING/PROCESSING), drop
+  // the update silently. Out-of-order callback after the row already settled.
+  try {
+    const current = await prisma.matchJob.findUnique({
+      where: { id },
+      select: { status: true },
+    });
+    if (!current) {
+      return NextResponse.json({ error: "Match job not found" }, { status: 404 });
+    }
+    if (TERMINAL_STATUSES.has(current.status)) {
+      const incomingStatus = data.status as MatchJobStatus | undefined;
+      if (incomingStatus && !TERMINAL_STATUSES.has(incomingStatus)) {
+        return NextResponse.json({ ok: true, ignored: "already terminal" });
+      }
+    }
+
+    await prisma.matchJob.update({ where: { id }, data });
+  } catch (err) {
+    console.error(`[matcher/internal] Failed to update job ${id}:`, err);
+    return NextResponse.json({ error: "Failed to update match job" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/lib/matcher/hooks.ts
+++ b/apps/web/lib/matcher/hooks.ts
@@ -85,6 +85,12 @@ export function useJobProgress(
           setIsLoading(false);
           eventSource.close();
           sseConnections.delete(jobId);
+
+          // Defence-in-depth: pull the latest persisted row so the UI sees the
+          // FAILED status + error_message even if the workflows-api → Next.js
+          // callback ever fails. Mirrors the COMPLETED branch above.
+          matcherClient.getJob(jobId).catch(console.error);
+
           if (onErrorRef.current) {
             onErrorRef.current(new Error(data.errorMessage || "Job failed"));
           }


### PR DESCRIPTION
Make Postgres the single source of truth for MatchJob status. workflows-api pushes status updates to Next.js via a token-authed callback whenever the workflow's status flips. Eliminates ghost PROCESSING rows after deploy / FAILED / user-leaves-page.

- New internal route apps/web/app/api/internal/matcher/jobs/[id]/route.ts accepts snake_case payloads, coerces to camelCase, writes Prisma directly. Bearer-token auth via INTERNAL_CALLBACK_TOKEN; X-Internal-Token accepted for compat. Idempotent: ignores updates that would un-terminate a row.
- JobStore.update_job fires _post_status_callback only on genuine status transitions (not progress ticks). 5 s urllib timeout; failures log and never raise.
- _run_and_persist gains a try / except CancelledError / except / finally that GUARANTEES terminal status before return. SIGTERM mid-rank now ends FAILED with error_message="cancelled".
- useJobProgress also calls matcherClient.getJob in the FAILED branch (defence in depth if the callback ever drops).