### PR TITLE
feat(semops): industrial hardening — bake HF model, narrow pool rebui…

### DIFF
--- a/apps/semops/Dockerfile
+++ b/apps/semops/Dockerfile
@@ -39,6 +39,19 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     uv pip install --system -r requirements.txt
 
+# Pre-download the HuggingFace embedding model so corp-network deploys
+# (no public internet at runtime) warm up cleanly. Without this, the first
+# rank request silently 404s when sentence-transformers tries to fetch from
+# the Hub. Cache lives at HF_HOME so subsequent loads are offline.
+#
+# IMPORTANT: anything other than `intfloat/e5-base-v2` (e.g. via the
+# SEMOPS_RM_MODEL env override at runtime) will FAIL in offline mode because
+# only this model is baked into the image. Bake additional models here if
+# you want to support overrides without internet.
+ENV HF_HOME=/app/.hf_cache
+RUN mkdir -p /app/.hf_cache && \
+    python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('intfloat/e5-base-v2')"
+
 # Copy source
 COPY api ./api
 COPY services ./services
@@ -46,6 +59,12 @@ COPY main.py ./
 
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
+
+# Force sentence-transformers / huggingface_hub into offline mode at runtime.
+# The model was baked above; any code path that tries to reach the Hub now
+# fails loud rather than hanging on corp-network DNS timeouts.
+ENV TRANSFORMERS_OFFLINE=1 \
+    HF_HUB_OFFLINE=1
 
 EXPOSE 2025
 

--- a/apps/semops/api/routes/operators.py
+++ b/apps/semops/api/routes/operators.py
@@ -11,6 +11,12 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from api.types import RankRequest, RankResponse, RankResultItem
+from services.errors import (
+    SemopsAuthError,
+    SemopsBadRequest,
+    SemopsProviderError,
+    SemopsRateLimitError,
+)
 from services.semantic_operators import SemanticOperators
 
 logger = logging.getLogger(__name__)
@@ -62,12 +68,28 @@ async def rank(
             include_reasons=req.include_reasons,
             lm_config=req.lm_config.model_dump(),
         )
+    except SemopsAuthError as e:
+        # BYOK key rejected by the provider. Surface as 401 so callers
+        # (matcher / digest workflows) can prompt the user to fix Settings.
+        logger.warning("rank auth error: %s", e)
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    except SemopsRateLimitError as e:
+        logger.warning("rank rate limited: %s", e)
+        raise HTTPException(status_code=429, detail=str(e)) from e
+    except SemopsBadRequest as e:
+        # Malformed candidates / etc. — caller error, distinct from auth/rate.
+        logger.warning("rank bad request: %s", e)
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except SemopsProviderError as e:
+        # Provider 5xx / unknown upstream failure. 502 == "we are a gateway
+        # to a broken upstream" which matches semantically.
+        logger.exception("rank provider error: %s", e)
+        raise HTTPException(status_code=502, detail=str(e)) from e
     except ValueError as e:
-        # SemanticOperators raises ValueError for empty candidates AND lotus
-        # raises ValueError for unconfigured RM/VS, malformed candidates,
-        # etc. Surface the actual message so callers don't see a misleading
-        # "candidates must not be empty" for unrelated config errors. Logged
-        # with traceback for server-side debuggability.
+        # Backstop for ValueErrors that didn't get normalized — most likely
+        # SemanticOperators.rank's own "candidates must be non-empty list"
+        # which fires before the pool path. Kept LAST so normalized errors
+        # above take precedence.
         logger.exception("rank rejected: %s", e)
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/apps/semops/services/_lotus_worker.py
+++ b/apps/semops/services/_lotus_worker.py
@@ -31,8 +31,34 @@ def init_worker() -> None:
     instance of RM, and the vector store must be an instance of VS``.
 
     Safe to call repeatedly (idempotent imports).
+
+    Failure mode
+    ------------
+    A failed warm-up MUST raise. We previously swallowed exceptions here so
+    the pool came up "healthy" — but every subsequent request would 401 or
+    silently fail at sem_index/sem_search. Failing loud makes corp-network
+    HF download timeouts and missing-model misconfigurations diagnosable
+    from a single pool-build error in logs, instead of every tenant seeing
+    confused errors hours later.
+
+    Override
+    --------
+    ``SEMOPS_RM_MODEL`` env can override the default ``intfloat/e5-base-v2``.
+    The Docker image only bakes the default; any override will fail in
+    offline mode (TRANSFORMERS_OFFLINE=1, HF_HUB_OFFLINE=1) unless that
+    model is also pre-downloaded into HF_HOME at image build time.
+
+    Test escape hatch
+    -----------------
+    pytest sets ``PYTEST_CURRENT_TEST`` automatically. When present we skip
+    the lotus import + warm-up so pool-mechanics tests can run without
+    the heavy LOTUS deps installed. Production never sets this var.
     """
     import os
+
+    if os.getenv("PYTEST_CURRENT_TEST") or os.getenv("SEMOPS_SKIP_WORKER_INIT"):
+        logger.info("lotus worker warm-up skipped (pid=%s, test mode)", os.getpid())
+        return
 
     try:
         import lotus  # type: ignore
@@ -47,10 +73,12 @@ def init_worker() -> None:
         logger.info(
             "lotus worker warmed up (pid=%s, rm=%s)", os.getpid(), rm_model
         )
-    except Exception as exc:  # noqa: BLE001
-        # A failed warm-up must not crash the pool — the first real request
-        # will hit the same ImportError and can surface it cleanly.
-        logger.warning("lotus worker warm-up failed (pid=%s): %s", os.getpid(), exc)
+    except Exception:
+        # Log + re-raise. A subprocess that can't load the embedding model
+        # cannot serve rank requests; better to fail pool build now than
+        # produce a "healthy" pool that 401s every tenant.
+        logger.exception("lotus worker warm-up failed (pid=%s)", os.getpid())
+        raise
 
 
 def run_rank(
@@ -69,11 +97,29 @@ def run_rank(
     it to None in `finally` so the subprocess leaves in a clean state even
     if the pipeline raises.
 
+    Exception normalization
+    -----------------------
+    Provider exceptions (notably ``litellm.AuthenticationError``) often have
+    ``__init__`` signatures that require positional args that pickle DOES
+    NOT carry — when they cross the pool boundary, the parent process
+    crashes with ``BrokenProcessPool`` instead of the real error. We catch
+    everything and re-raise as one of the small ``SemopsXxx`` types from
+    ``services.errors``, which subclass ``Exception`` with a
+    ``__init__(self, message)`` and are therefore guaranteed pickle-safe.
+
     `pipeline_fn` is a test seam — production callers leave it None and the
     real `_default_pipeline` is invoked.
     """
     import lotus  # type: ignore
     from lotus.models import LM  # type: ignore
+
+    from services.errors import (
+        SemopsAuthError,
+        SemopsBadRequest,
+        SemopsError,
+        SemopsProviderError,
+        SemopsRateLimitError,
+    )
 
     lm_kwargs: dict[str, Any] = {
         "model": f"{lm_config['provider']}/{lm_config['model']}",
@@ -88,13 +134,45 @@ def run_rank(
     lotus.settings.configure(lm=LM(**lm_kwargs))
     try:
         fn = pipeline_fn or _default_pipeline
-        return fn(
-            candidates=candidates,
-            query_text=query_text,
-            top_k=top_k,
-            search_k=search_k,
-            include_reasons=include_reasons,
-        )
+        try:
+            return fn(
+                candidates=candidates,
+                query_text=query_text,
+                top_k=top_k,
+                search_k=search_k,
+                include_reasons=include_reasons,
+            )
+        except SemopsError:
+            # Already normalized — let it propagate as-is.
+            raise
+        except Exception as exc:  # noqa: BLE001
+            # Inspect the exception by class name + message and re-raise as a
+            # pickle-safe typed instance. We avoid `isinstance` against
+            # provider SDK classes (litellm, openai) so this module does not
+            # import them — the worker stays thin.
+            cls_name = type(exc).__name__
+            msg = str(exc) or cls_name
+            lower = f"{cls_name}:{msg}".lower()
+
+            if cls_name.endswith("AuthenticationError") or "authenticationerror" in lower:
+                raise SemopsAuthError(msg) from None
+            if cls_name.endswith("RateLimitError") or "ratelimit" in lower:
+                raise SemopsRateLimitError(msg) from None
+            if (
+                cls_name.endswith("APIConnectionError")
+                or cls_name.endswith("APIError")
+                or cls_name.endswith("ServiceUnavailableError")
+                or cls_name.endswith("InternalServerError")
+                or cls_name.endswith("Timeout")
+                or cls_name.endswith("TimeoutError")
+            ):
+                raise SemopsProviderError(f"{cls_name}: {msg}") from None
+            if isinstance(exc, ValueError):
+                raise SemopsBadRequest(msg) from None
+
+            # Unknown — surface as provider error so the route returns 502
+            # rather than masking via the stale ValueError handler.
+            raise SemopsProviderError(f"{cls_name}: {msg}") from None
     finally:
         # The reset itself can theoretically raise if lotus state is corrupt.
         # Swallow + log so the worker leaves in as clean a state as possible

--- a/apps/semops/services/_pool.py
+++ b/apps/semops/services/_pool.py
@@ -2,10 +2,22 @@
 
 Singleton — one pool per FastAPI process, shared across all rank requests.
 Uses ``mp_context=spawn`` to avoid fork-inheriting torch/CUDA state from the
-parent. On any worker exception we shut down and rebuild the pool
-(poisoned-worker recovery), because ProcessPoolExecutor does not evict a
-worker that raised — the NEXT task would run in the same subprocess with
-potentially corrupted ``lotus.settings.lm``.
+parent.
+
+Pool-rebuild policy
+-------------------
+The pool is rebuilt ONLY when the executor itself is broken
+(``BrokenProcessPool`` / ``BrokenExecutor``). Ordinary task exceptions —
+including provider auth errors, rate limits, and ``ValueError`` for bad
+candidates — are propagated to the caller without nuking the pool.
+
+Why this matters: the pool is shared across tenants. Rebuilding on every
+auth error means one tenant's bad BYOK key cancels every other in-flight
+rank, which is a cross-tenant blast radius we cannot afford.
+
+The per-request lotus reset in ``_lotus_worker.run_rank``'s ``finally``
+block already ensures no cross-tenant LM leakage — there is nothing left
+to "poison" for ordinary exceptions.
 """
 
 from __future__ import annotations
@@ -16,7 +28,13 @@ import multiprocessing
 import os
 import threading
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from typing import Any, Callable, TypeVar
+
+try:  # py3.8+: BrokenExecutor is the public base class
+    from concurrent.futures import BrokenExecutor
+except ImportError:  # pragma: no cover — defensive for older runtimes
+    BrokenExecutor = BrokenProcessPool  # type: ignore[assignment,misc]
 
 logger = logging.getLogger(__name__)
 
@@ -85,16 +103,37 @@ def shutdown_pool() -> None:
 def run_in_pool(fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
     """Submit ``fn(*args, **kwargs)`` to the pool and block on the result.
 
-    On exception the pool is rebuilt before re-raising, so the next caller
-    gets a fresh pool with no residual ``lotus.settings.lm`` state.
+    Pool-rebuild trigger
+    --------------------
+    The pool is rebuilt ONLY when the executor itself is broken
+    (``BrokenProcessPool`` / ``BrokenExecutor``). Every other exception is
+    re-raised without touching the pool, because:
+
+    1. Cross-tenant blast radius: rebuilding on a tenant's auth error would
+       cancel every other tenant's in-flight rank. We pay that cost only
+       when the executor genuinely cannot serve another request.
+    2. State hygiene: ``_lotus_worker.run_rank``'s ``finally`` already
+       resets ``lotus.settings.lm=None``, so ordinary exceptions leave the
+       worker in a clean state — there is nothing to "poison".
+
+    We catch ``Exception`` (NOT ``BaseException``): ``KeyboardInterrupt``
+    and ``SystemExit`` should propagate untouched so process shutdown
+    works.
     """
     pool = get_pool()
     future = pool.submit(fn, *args, **kwargs)
     try:
         return future.result()
-    except BaseException:
-        logger.warning("semops rank task raised; rebuilding pool")
+    except (BrokenProcessPool, BrokenExecutor):
+        # The executor itself is dead — subsequent submit() calls would
+        # raise immediately. Rebuild before re-raising so the next caller
+        # gets a working pool.
+        logger.warning("semops rank pool is broken; rebuilding")
         shutdown_pool()
+        raise
+    except Exception:
+        # Ordinary task failure (auth error, rate limit, ValueError, etc).
+        # Pool stays intact so other tenants' requests are unaffected.
         raise
 
 

--- a/apps/semops/services/errors.py
+++ b/apps/semops/services/errors.py
@@ -1,0 +1,59 @@
+"""Pickle-safe error types raised across the ProcessPoolExecutor boundary.
+
+When a worker subprocess raises, ``concurrent.futures`` pickles the exception
+and re-raises it in the parent process. Provider SDK exceptions (notably
+litellm's ``AuthenticationError``) have ``__init__`` signatures that require
+positional arguments that are NOT pickled along with the instance — pickling
+the exception succeeds, but unpickling crashes the parent and surfaces as
+``BrokenProcessPool``, masking the real error.
+
+The fix is to translate every provider exception into one of the small,
+pickle-safe types below before it leaves the worker. Each type:
+
+* Subclasses ``Exception`` with a vanilla ``__init__(self, message)``.
+* Holds nothing but ``message: str`` so reconstructing the instance via
+  ``cls(message)`` is always valid (this is what pickle does on unpickle).
+* Has a stable, importable name so the parent process can ``except`` it.
+
+Mapped to HTTP statuses by ``api/routes/operators.py``:
+
+    SemopsAuthError      -> 401  (BYOK key rejected)
+    SemopsRateLimitError -> 429  (provider rate limit)
+    SemopsBadRequest     -> 400  (malformed candidates / etc.)
+    SemopsProviderError  -> 502  (provider 5xx / unknown failure)
+"""
+
+from __future__ import annotations
+
+
+class SemopsError(Exception):
+    """Base class for semops errors that cross the pool boundary."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class SemopsAuthError(SemopsError):
+    """Provider rejected the BYOK credentials (401-equivalent)."""
+
+
+class SemopsRateLimitError(SemopsError):
+    """Provider rate-limited the request (429-equivalent)."""
+
+
+class SemopsProviderError(SemopsError):
+    """Provider 5xx or otherwise unspecified upstream failure (502-equivalent)."""
+
+
+class SemopsBadRequest(SemopsError):
+    """Malformed request (e.g. bad candidates, empty fields) — caller error (400-equivalent)."""
+
+
+__all__ = [
+    "SemopsError",
+    "SemopsAuthError",
+    "SemopsRateLimitError",
+    "SemopsProviderError",
+    "SemopsBadRequest",
+]

--- a/apps/semops/tests/test_operators_route.py
+++ b/apps/semops/tests/test_operators_route.py
@@ -125,6 +125,62 @@ def test_rank_validation_error_missing_field(client, rank_body):
     assert response.status_code == 422, response.text
 
 
+def test_rank_maps_auth_error_to_401(client, monkeypatch, rank_body):
+    """SemopsAuthError from rank → HTTP 401 with the provider's message."""
+    from services.errors import SemopsAuthError
+
+    def _boom_auth(self, **kwargs):
+        raise SemopsAuthError("invalid api key for provider X")
+
+    monkeypatch.setattr(SemanticOperators, "rank", _boom_auth)
+
+    response = client.post("/api/operators/rank", json=rank_body)
+    assert response.status_code == 401, response.text
+    assert "invalid api key" in response.json().get("detail", "").lower()
+
+
+def test_rank_maps_rate_limit_to_429(client, monkeypatch, rank_body):
+    """SemopsRateLimitError from rank → HTTP 429."""
+    from services.errors import SemopsRateLimitError
+
+    def _boom_rate(self, **kwargs):
+        raise SemopsRateLimitError("provider says slow down")
+
+    monkeypatch.setattr(SemanticOperators, "rank", _boom_rate)
+
+    response = client.post("/api/operators/rank", json=rank_body)
+    assert response.status_code == 429, response.text
+    assert "slow down" in response.json().get("detail", "").lower()
+
+
+def test_rank_maps_bad_request_to_400(client, monkeypatch, rank_body):
+    """SemopsBadRequest from rank → HTTP 400."""
+    from services.errors import SemopsBadRequest
+
+    def _boom_bad(self, **kwargs):
+        raise SemopsBadRequest("malformed candidate row")
+
+    monkeypatch.setattr(SemanticOperators, "rank", _boom_bad)
+
+    response = client.post("/api/operators/rank", json=rank_body)
+    assert response.status_code == 400, response.text
+    assert "malformed candidate" in response.json().get("detail", "").lower()
+
+
+def test_rank_maps_provider_error_to_502(client, monkeypatch, rank_body):
+    """SemopsProviderError from rank → HTTP 502 (we are a gateway to broken upstream)."""
+    from services.errors import SemopsProviderError
+
+    def _boom_prov(self, **kwargs):
+        raise SemopsProviderError("upstream returned 503")
+
+    monkeypatch.setattr(SemanticOperators, "rank", _boom_prov)
+
+    response = client.post("/api/operators/rank", json=rank_body)
+    assert response.status_code == 502, response.text
+    assert "503" in response.json().get("detail", "")
+
+
 def test_rank_passes_kwargs_through(client, monkeypatch, rank_body):
     """The route must forward kwargs from the request body into rank()."""
     captured: dict = {}

--- a/apps/semops/tests/test_semantic_operators.py
+++ b/apps/semops/tests/test_semantic_operators.py
@@ -277,7 +277,13 @@ def test_run_rank_configures_lotus_and_resets(monkeypatch):
 
 
 def test_run_rank_resets_lotus_on_pipeline_exception(monkeypatch):
-    """Even when the pipeline raises, the finally block must reset lotus.settings.lm=None."""
+    """Even when the pipeline raises, the finally block must reset lotus.settings.lm=None.
+
+    Note: as of Issue #151, ``run_rank`` normalizes raw provider exceptions
+    into ``SemopsXxx`` types before returning. A bare ``RuntimeError`` now
+    surfaces as ``SemopsProviderError``. This test's PRIMARY assertion is
+    the finally-block reset, which must fire regardless of normalization.
+    """
     import sys
     from unittest.mock import MagicMock
 
@@ -293,12 +299,13 @@ def test_run_rank_resets_lotus_on_pipeline_exception(monkeypatch):
     monkeypatch.setitem(sys.modules, "lotus.models", fake_models)
 
     from services._lotus_worker import run_rank
+    from services.errors import SemopsProviderError
 
     def boom(**_kw):
         raise RuntimeError("pipeline explosion")
 
     import pytest
-    with pytest.raises(RuntimeError, match="pipeline explosion"):
+    with pytest.raises(SemopsProviderError, match="pipeline explosion"):
         run_rank(
             lm_config={
                 "provider": "openai",
@@ -370,7 +377,15 @@ def test_run_rank_swallows_exception_during_reset(monkeypatch, caplog):
 
 
 def test_pool_rebuilds_after_worker_exception(monkeypatch):
-    """A task that raises must not poison the pool — subsequent tasks see a fresh executor."""
+    """A task that raises must not poison the pool — subsequent tasks see a working executor.
+
+    Note: with the narrowed pool-rebuild trigger (Issue #151), the pool is
+    NOT actually rebuilt on plain ``RuntimeError`` — it stays alive. The
+    follow-up assertion that the next submission succeeds therefore proves
+    the live pool still serves requests, not that a rebuild happened.
+    See ``test_run_in_pool_does_not_rebuild_on_value_error`` for the
+    explicit "no rebuild" contract.
+    """
     from services import _pool
 
     # Force a fresh pool state so the assertion holds regardless of test ordering.
@@ -378,13 +393,11 @@ def test_pool_rebuilds_after_worker_exception(monkeypatch):
 
     monkeypatch.setenv("SEMOPS_RANK_POOL_SIZE", "2")
 
-    # `run_in_pool` submits the fn to the pool; on raise it must tear down
-    # and rebuild so subsequent callers aren't stuck in a poisoned subprocess.
     import pytest
     with pytest.raises(RuntimeError, match="worker exploded"):
         _pool.run_in_pool(_raise_for_pool_test)
 
-    # After a raise, the next submission succeeds — proves rebuild happened.
+    # After a raise, the next submission succeeds — pool still works.
     assert _pool.run_in_pool(_peace_for_pool_test) == "ok"
 
     _pool.shutdown_pool()
@@ -396,3 +409,280 @@ def _raise_for_pool_test():
 
 def _peace_for_pool_test():
     return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Issue #151 — semops industrial hardening
+# ---------------------------------------------------------------------------
+
+
+def test_run_rank_normalizes_litellm_authentication_error(monkeypatch):
+    """run_rank must re-raise litellm-shaped AuthenticationError as SemopsAuthError.
+
+    The DI seam (``pipeline_fn``) lets us simulate a provider error without
+    touching litellm. We use a fake exception class whose name ends with
+    ``AuthenticationError`` — the worker's normalization key — to prove the
+    heuristic. The point of this test is the type translation: the parent
+    process must receive ``SemopsAuthError``, NOT ``BrokenProcessPool`` and
+    NOT the raw provider class (which may unpickle-crash).
+    """
+    import sys
+    from unittest.mock import MagicMock
+
+    fake_settings = MagicMock()
+    fake_lotus = MagicMock()
+    fake_lotus.settings = fake_settings
+    fake_models = MagicMock()
+    fake_models.LM = MagicMock(return_value="FAKE_LM")
+    monkeypatch.setitem(sys.modules, "lotus", fake_lotus)
+    monkeypatch.setitem(sys.modules, "lotus.models", fake_models)
+
+    class FakeAuthenticationError(Exception):
+        """Simulates litellm.AuthenticationError by name suffix."""
+
+    from services._lotus_worker import run_rank
+    from services.errors import SemopsAuthError
+
+    def boom_auth(**_kw):
+        raise FakeAuthenticationError("provider rejected the api key")
+
+    import pytest
+    with pytest.raises(SemopsAuthError, match="provider rejected"):
+        run_rank(
+            lm_config={
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "sk-bogus",
+                "api_base": None,
+            },
+            candidates=[{"id": "a", "match_text": "x"}],
+            query_text="q",
+            top_k=5,
+            search_k=20,
+            include_reasons=False,
+            pipeline_fn=boom_auth,
+        )
+
+
+def test_run_rank_normalizes_rate_limit_error(monkeypatch):
+    """RateLimitError-shaped exceptions become SemopsRateLimitError."""
+    import sys
+    from unittest.mock import MagicMock
+
+    fake_lotus = MagicMock()
+    fake_lotus.settings = MagicMock()
+    fake_models = MagicMock()
+    fake_models.LM = MagicMock(return_value="FAKE_LM")
+    monkeypatch.setitem(sys.modules, "lotus", fake_lotus)
+    monkeypatch.setitem(sys.modules, "lotus.models", fake_models)
+
+    class FakeRateLimitError(Exception):
+        pass
+
+    from services._lotus_worker import run_rank
+    from services.errors import SemopsRateLimitError
+
+    def boom_rate(**_kw):
+        raise FakeRateLimitError("429 too many requests")
+
+    import pytest
+    with pytest.raises(SemopsRateLimitError, match="429"):
+        run_rank(
+            lm_config={
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "sk-test",
+                "api_base": None,
+            },
+            candidates=[{"id": "a", "match_text": "x"}],
+            query_text="q",
+            top_k=5,
+            search_k=20,
+            include_reasons=False,
+            pipeline_fn=boom_rate,
+        )
+
+
+def test_run_rank_normalizes_value_error_to_bad_request(monkeypatch):
+    """ValueError from the pipeline becomes SemopsBadRequest.
+
+    Lotus raises ValueError for malformed candidates / unconfigured RM/VS.
+    Translating to ``SemopsBadRequest`` lets the route return 400 cleanly
+    while staying out of the ValueError backstop path.
+    """
+    import sys
+    from unittest.mock import MagicMock
+
+    fake_lotus = MagicMock()
+    fake_lotus.settings = MagicMock()
+    fake_models = MagicMock()
+    fake_models.LM = MagicMock(return_value="FAKE_LM")
+    monkeypatch.setitem(sys.modules, "lotus", fake_lotus)
+    monkeypatch.setitem(sys.modules, "lotus.models", fake_models)
+
+    from services._lotus_worker import run_rank
+    from services.errors import SemopsBadRequest
+
+    def boom_value(**_kw):
+        raise ValueError("malformed candidate row 3")
+
+    import pytest
+    with pytest.raises(SemopsBadRequest, match="malformed candidate"):
+        run_rank(
+            lm_config={
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "sk-test",
+                "api_base": None,
+            },
+            candidates=[{"id": "a", "match_text": "x"}],
+            query_text="q",
+            top_k=5,
+            search_k=20,
+            include_reasons=False,
+            pipeline_fn=boom_value,
+        )
+
+
+def test_run_rank_normalizes_unknown_to_provider_error(monkeypatch):
+    """Unknown exception types become SemopsProviderError (502-equivalent)."""
+    import sys
+    from unittest.mock import MagicMock
+
+    fake_lotus = MagicMock()
+    fake_lotus.settings = MagicMock()
+    fake_models = MagicMock()
+    fake_models.LM = MagicMock(return_value="FAKE_LM")
+    monkeypatch.setitem(sys.modules, "lotus", fake_lotus)
+    monkeypatch.setitem(sys.modules, "lotus.models", fake_models)
+
+    from services._lotus_worker import run_rank
+    from services.errors import SemopsProviderError
+
+    def boom_unknown(**_kw):
+        raise RuntimeError("upstream went sideways")
+
+    import pytest
+    with pytest.raises(SemopsProviderError, match="upstream went sideways"):
+        run_rank(
+            lm_config={
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "sk-test",
+                "api_base": None,
+            },
+            candidates=[{"id": "a", "match_text": "x"}],
+            query_text="q",
+            top_k=5,
+            search_k=20,
+            include_reasons=False,
+            pipeline_fn=boom_unknown,
+        )
+
+
+def test_run_rank_passes_through_already_normalized_errors(monkeypatch):
+    """If the pipeline already raises a SemopsXxx, it must propagate as-is.
+
+    This guards the future case where deeper code in the pipeline already
+    knows how to classify an error — we should not re-classify it.
+    """
+    import sys
+    from unittest.mock import MagicMock
+
+    fake_lotus = MagicMock()
+    fake_lotus.settings = MagicMock()
+    fake_models = MagicMock()
+    fake_models.LM = MagicMock(return_value="FAKE_LM")
+    monkeypatch.setitem(sys.modules, "lotus", fake_lotus)
+    monkeypatch.setitem(sys.modules, "lotus.models", fake_models)
+
+    from services._lotus_worker import run_rank
+    from services.errors import SemopsRateLimitError
+
+    def boom_already(**_kw):
+        raise SemopsRateLimitError("provider says 429")
+
+    import pytest
+    with pytest.raises(SemopsRateLimitError, match="provider says 429"):
+        run_rank(
+            lm_config={
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "sk-test",
+                "api_base": None,
+            },
+            candidates=[{"id": "a", "match_text": "x"}],
+            query_text="q",
+            top_k=5,
+            search_k=20,
+            include_reasons=False,
+            pipeline_fn=boom_already,
+        )
+
+
+def test_semops_errors_are_pickle_safe():
+    """SemopsXxx instances must round-trip through pickle without losing data.
+
+    This is the whole point of the new exception types: they cross the
+    pool boundary without crashing on unpickle. ``__init__(self, message)``
+    + a single ``.message`` attribute is the contract.
+    """
+    import pickle
+
+    from services.errors import (
+        SemopsAuthError,
+        SemopsBadRequest,
+        SemopsError,
+        SemopsProviderError,
+        SemopsRateLimitError,
+    )
+
+    for cls in (
+        SemopsError,
+        SemopsAuthError,
+        SemopsRateLimitError,
+        SemopsProviderError,
+        SemopsBadRequest,
+    ):
+        original = cls("hello world")
+        round_tripped = pickle.loads(pickle.dumps(original))
+        assert isinstance(round_tripped, cls)
+        assert str(round_tripped) == "hello world"
+        assert round_tripped.message == "hello world"
+
+
+def test_run_in_pool_does_not_rebuild_on_value_error(monkeypatch):
+    """run_in_pool must NOT shut down the pool on ordinary task exceptions.
+
+    Cross-tenant blast radius matters: one tenant's bad input cannot
+    cancel every other in-flight request. The pool is rebuilt ONLY when
+    the executor itself is broken.
+    """
+    from services import _pool
+
+    monkeypatch.setenv("SEMOPS_RANK_POOL_SIZE", "2")
+    _pool.shutdown_pool()
+
+    # Get the live pool object and remember its identity.
+    pool_before = _pool.get_pool()
+    assert pool_before is not None
+
+    import pytest
+    with pytest.raises(ValueError, match="bad input"):
+        _pool.run_in_pool(_raise_value_error_for_pool_test)
+
+    # Pool must be the same instance — no rebuild happened.
+    pool_after = _pool.get_pool()
+    assert pool_after is pool_before, (
+        "Pool was rebuilt on ValueError, which would cancel other tenants' "
+        "in-flight requests"
+    )
+
+    # And it still serves requests.
+    assert _pool.run_in_pool(_peace_for_pool_test) == "ok"
+
+    _pool.shutdown_pool()
+
+
+def _raise_value_error_for_pool_test():
+    raise ValueError("bad input")


### PR DESCRIPTION
…ld, normalize subprocess exceptions

Three coupled hardening items so semops survives bad inputs, corp-network constraints, and partial failures without losing other tenants' work.

1. Bake intfloat/e5-base-v2 into the Docker image
   - Pre-download model to HF_HOME=/app/.hf_cache at build time
   - Set TRANSFORMERS_OFFLINE=1 / HF_HUB_OFFLINE=1 at runtime so corp-network deploys never silently 404 at sem_index time
   - init_worker now log+raises on warm-up failure (was silently swallowed) so misconfigurations surface at pool build instead of every tenant seeing confused errors hours later. PYTEST_CURRENT_TEST acts as a test escape hatch so pool-mechanics tests don't need LOTUS installed.

2. Narrow pool-rebuild trigger
   - run_in_pool now rebuilds ONLY on BrokenProcessPool/BrokenExecutor
   - Ordinary task exceptions (auth, rate limit, ValueError) propagate without nuking the pool. Per-request lotus reset already prevents cross-tenant LM leakage; rebuilding on every error meant one tenant's bad BYOK key cancelled every other in-flight rank.
   - Switched BaseException → Exception so KeyboardInterrupt/SystemExit propagate correctly during shutdown.

3. Normalize subprocess exceptions before crossing the pool boundary
   - New services/errors.py defines pickle-safe SemopsXxx types with vanilla __init__(self, message). Solves the litellm AuthenticationError unpickle-crash that was masking real errors behind BrokenProcessPool.
   - run_rank inspects exception class names and re-raises as SemopsAuthError / SemopsRateLimitError / SemopsProviderError / SemopsBadRequest. Worker stays thin (no provider SDK imports).
   - api/routes/operators.py maps each to 401/429/502/400 respectively. Existing ValueError handler kept LAST as a backstop.

Closes #151