### PR TITLE
refactor(matcher langgraph): collapse vacuous classes + delete dead index_dir (#154 langgraph slice)

### DIFF
--- a/apps/langgraph/server/routes/matcher_jobs.py
+++ b/apps/langgraph/server/routes/matcher_jobs.py
@@ -12,10 +12,10 @@ import logging
 from datetime import datetime, timezone
 
 import pandas as pd
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
+from workflows.matcher import job_store
 from workflows.matcher.job import match_job_graph
-from workflows.matcher.job_store import JobStore
 
 from server.matcher_types import (
     CreateMatchJobRequest,
@@ -28,10 +28,6 @@ from server.matcher_types import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-def get_job_store() -> JobStore:
-    return JobStore()
 
 
 async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data: list[dict]):
@@ -52,8 +48,6 @@ async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data:
     error_message="cancelled" and re-raises (must propagate to honour the
     cancellation contract).
     """
-    store = JobStore()
-
     try:
 
         class _Req:
@@ -84,7 +78,7 @@ async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data:
             {"job_id": job_id, "target_df": target_df, "req": graph_req, "results_by_bu": {}},
             run_config,
         )
-        store.update_job(
+        job_store.update_job(
             job_id,
             status="COMPLETED",
             progress=100,
@@ -98,7 +92,7 @@ async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data:
         # to flush a terminal status to the row first. CancelledError doesn't
         # derive from Exception in 3.8+, so the broader except below misses it.
         logger.warning(f"Job {job_id} cancelled mid-run")
-        store.update_job(
+        job_store.update_job(
             job_id,
             status="FAILED",
             error_message="cancelled",
@@ -107,7 +101,7 @@ async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data:
         raise
     except Exception as exc:  # noqa: BLE001
         logger.exception(f"Job {job_id} failed: {exc}")
-        store.update_job(
+        job_store.update_job(
             job_id,
             status="FAILED",
             error_message=str(exc),
@@ -117,13 +111,13 @@ async def _run_and_persist(job_id: str, req: CreateMatchJobRequest, target_data:
         # Belt-and-braces: if some path above failed to write a terminal
         # status (e.g. exception inside an exception handler, sync bug),
         # force one here so the row never lingers at PROCESSING.
-        job = store.get_job(job_id)
+        job = job_store.get_job(job_id)
         if job and job.get("status") not in {"COMPLETED", "FAILED", "CANCELLED"}:
             logger.warning(
                 f"Job {job_id} exited with non-terminal status "
                 f"{job.get('status')!r} — forcing FAILED"
             )
-            store.update_job(
+            job_store.update_job(
                 job_id,
                 status="FAILED",
                 error_message=job.get("error_message") or "unknown error",
@@ -136,7 +130,6 @@ async def create_job(
     req: CreateMatchJobRequest,
     background_tasks: BackgroundTasks,
     request: Request,
-    job_store: JobStore = Depends(get_job_store),
 ):
     if not req.queries:
         raise HTTPException(status_code=400, detail="No queries provided")
@@ -165,10 +158,7 @@ async def create_job(
 
 
 @router.get("/jobs/{job_id}", response_model=MatchJobResponse)
-async def get_job(
-    job_id: str,
-    job_store: JobStore = Depends(get_job_store),
-):
+async def get_job(job_id: str):
     job = job_store.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -176,10 +166,7 @@ async def get_job(
 
 
 @router.get("/jobs/{job_id}/progress", response_model=JobProgressResponse)
-async def get_job_progress(
-    job_id: str,
-    job_store: JobStore = Depends(get_job_store),
-):
+async def get_job_progress(job_id: str):
     job = job_store.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -194,10 +181,7 @@ async def get_job_progress(
 
 
 @router.get("/jobs/{job_id}/stream")
-async def stream_job_progress(
-    job_id: str,
-    job_store: JobStore = Depends(get_job_store),
-):
+async def stream_job_progress(job_id: str):
     """Stream job progress updates via SSE."""
 
     async def event_generator():
@@ -248,10 +232,7 @@ async def stream_job_progress(
 
 
 @router.delete("/jobs/{job_id}")
-async def cancel_job(
-    job_id: str,
-    job_store: JobStore = Depends(get_job_store),
-):
+async def cancel_job(job_id: str):
     job = job_store.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -262,10 +243,7 @@ async def cancel_job(
 
 
 @router.get("/jobs/{job_id}/download")
-async def download_results(
-    job_id: str,
-    job_store: JobStore = Depends(get_job_store),
-):
+async def download_results(job_id: str):
     job = job_store.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/apps/langgraph/tests/test_matcher_workflow.py
+++ b/apps/langgraph/tests/test_matcher_workflow.py
@@ -120,7 +120,6 @@ def test_orchestrator_groups_queries_by_bu(monkeypatch):
     assert set(out["queries_by_bu"].keys()) == {"BU_A", "BU_B"}
     assert out["queries_by_bu"]["BU_A"] == ["q1", "q1b"]
     assert set(out["optimized"].keys()) == {"BU_A", "BU_B"}
-    assert "index_dir" in out
     job = job_store.get_job(job_id)
     assert job["status"] == "PROCESSING"
     assert job["progress"] == 30
@@ -187,7 +186,6 @@ def test_assign_workers_emits_one_send_per_bu():
         "target_df": pd.DataFrame(),
         "req": _make_req([{"bu": "BU_A", "query": "q1"}]),
         "optimized": {"BU_A": _fake_optimized("BU_A"), "BU_B": _fake_optimized("BU_B")},
-        "index_dir": "/tmp/x",
     }
     sends = assign_workers(state)
     assert len(sends) == 2
@@ -205,7 +203,6 @@ def test_assign_workers_does_not_leak_secrets_in_send_args():
         "target_df": pd.DataFrame(),
         "req": _make_req([{"bu": "BU_A", "query": "q1"}]),
         "optimized": {"BU_A": _fake_optimized("BU_A")},
-        "index_dir": "/tmp/x",
     }
     sends = assign_workers(state)
     payload = repr(sends)
@@ -339,7 +336,6 @@ def test_api_key_does_not_appear_in_job_state_repr():
         "queries_by_bu": {"BU_A": ["q"]},
         "optimized": {},
         "results_by_bu": {},
-        "index_dir": "/tmp/x",
     }
     # Even with the secret available in the config, repr(state) cannot mention it.
     config = _make_config(api_key=secret)

--- a/apps/langgraph/tests/test_matcher_workflow.py
+++ b/apps/langgraph/tests/test_matcher_workflow.py
@@ -217,17 +217,20 @@ def test_assign_workers_does_not_leak_secrets_in_send_args():
 
 
 def test_rank_bu_invokes_lotus_and_returns_results_by_bu(monkeypatch):
-    fake_matcher = MagicMock()
-    fake_matcher.build_text_column = MagicMock(return_value=pd.DataFrame([{"id": 1}]))
-    fake_matcher.run_pipeline = MagicMock(return_value=pd.DataFrame([{"id": 1, "title": "match"}]))
-    monkeypatch.setattr("workflows.matcher.job.LotusMatcher", MagicMock(return_value=fake_matcher))
+    monkeypatch.setattr(
+        "workflows.matcher.job.build_text_column",
+        lambda df, target_type: pd.DataFrame([{"id": 1}]),
+    )
+    monkeypatch.setattr(
+        "workflows.matcher.job.rank_via_semops",
+        lambda **kwargs: pd.DataFrame([{"id": 1, "title": "match"}]),
+    )
 
     ws = {
         "bu": "BU_X",
         "optimized": _fake_optimized("BU_X"),
         "target_df": pd.DataFrame([{"id": 1}]),
         "req": _make_req([{"bu": "BU_X", "query": "q"}]),
-        "index_dir": "/tmp/x",
     }
     out = rank_bu(ws, _make_config())
     assert "results_by_bu" in out
@@ -238,24 +241,25 @@ def test_rank_bu_invokes_lotus_and_returns_results_by_bu(monkeypatch):
 
 
 def test_rank_bu_threads_lm_config_into_run_pipeline(monkeypatch):
-    """rank_bu reads BYOK creds from RunnableConfig and forwards to LotusMatcher."""
+    """rank_bu reads BYOK creds from RunnableConfig and forwards to rank_via_semops."""
     captured: dict = {}
-    fake_matcher = MagicMock()
-    fake_matcher.build_text_column = MagicMock(return_value=pd.DataFrame([{"id": 1}]))
 
-    def fake_run_pipeline(**kwargs):
+    monkeypatch.setattr(
+        "workflows.matcher.job.build_text_column",
+        lambda df, target_type: pd.DataFrame([{"id": 1}]),
+    )
+
+    def fake_rank_via_semops(**kwargs):
         captured.update(kwargs)
         return pd.DataFrame([{"id": 1, "title": "match"}])
 
-    fake_matcher.run_pipeline = fake_run_pipeline
-    monkeypatch.setattr("workflows.matcher.job.LotusMatcher", MagicMock(return_value=fake_matcher))
+    monkeypatch.setattr("workflows.matcher.job.rank_via_semops", fake_rank_via_semops)
 
     ws = {
         "bu": "BU_X",
         "optimized": _fake_optimized("BU_X"),
         "target_df": pd.DataFrame([{"id": 1}]),
         "req": _make_req([{"bu": "BU_X", "query": "q"}]),
-        "index_dir": "/tmp/x",
     }
     config = _make_config(
         provider="deepseek",
@@ -277,7 +281,6 @@ def test_rank_bu_raises_when_lm_config_missing():
         "optimized": _fake_optimized("BU_X"),
         "target_df": pd.DataFrame([{"id": 1}]),
         "req": _make_req([{"bu": "BU_X", "query": "q"}]),
-        "index_dir": "/tmp/x",
     }
     with pytest.raises(RuntimeError, match="BYOK lm_config"):
         rank_bu(ws, {"configurable": {}})
@@ -567,7 +570,7 @@ def test_run_pipeline_replaces_nan_with_none_before_serialization(monkeypatch):
 
     import numpy as np
 
-    from workflows.matcher.lotus import LotusMatcher
+    from workflows.matcher.lotus import rank_via_semops
 
     captured: dict = {}
 
@@ -586,7 +589,7 @@ def test_run_pipeline_replaces_nan_with_none_before_serialization(monkeypatch):
         ]
     )
 
-    LotusMatcher().run_pipeline(
+    rank_via_semops(
         df=df,
         query_text="q",
         query_name="test",

--- a/apps/langgraph/tests/test_matcher_workflow.py
+++ b/apps/langgraph/tests/test_matcher_workflow.py
@@ -27,14 +27,14 @@ from workflows.matcher.job import (
     rank_bu,
     synthesize,
 )
-from workflows.matcher.job_store import JobStore
+from workflows.matcher import job_store
 
 
 @pytest.fixture(autouse=True)
 def _reset_job_store():
-    JobStore()._jobs.clear()
+    job_store._jobs.clear()
     yield
-    JobStore()._jobs.clear()
+    job_store._jobs.clear()
 
 
 @pytest.fixture
@@ -100,7 +100,7 @@ def test_orchestrator_groups_queries_by_bu(monkeypatch):
             {"bu": "BU_B", "query": "q2"},
         ]
     )
-    job_id = JobStore().create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="publication",
@@ -121,7 +121,7 @@ def test_orchestrator_groups_queries_by_bu(monkeypatch):
     assert out["queries_by_bu"]["BU_A"] == ["q1", "q1b"]
     assert set(out["optimized"].keys()) == {"BU_A", "BU_B"}
     assert "index_dir" in out
-    job = JobStore().get_job(job_id)
+    job = job_store.get_job(job_id)
     assert job["status"] == "PROCESSING"
     assert job["progress"] == 30
 
@@ -137,7 +137,7 @@ def test_orchestrator_passes_lm_config_to_optimizer(monkeypatch):
     monkeypatch.setattr("workflows.matcher.job.optimize_queries", fake_optimize)
 
     req = _make_req([{"bu": "BU_A", "query": "q1"}])
-    job_id = JobStore().create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="publication",
@@ -164,7 +164,7 @@ def test_orchestrator_passes_lm_config_to_optimizer(monkeypatch):
 def test_orchestrator_raises_when_lm_config_missing():
     """Without a BYOK lm_config the matcher cannot run; surface immediately."""
     req = _make_req([{"bu": "BU_A", "query": "q1"}])
-    job_id = JobStore().create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="publication",
@@ -289,7 +289,7 @@ def test_synthesize_writes_excel_bytes_and_total_matches(monkeypatch):
     monkeypatch.setattr("workflows.matcher.job.ExcelProcessor", fake_xls)
     monkeypatch.setattr("workflows.matcher.job._build_master", lambda df, rbu, ir: df)
 
-    job_id = JobStore().create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="publication",
@@ -515,7 +515,7 @@ def test_run_and_persist_passes_lm_config_via_runnable_config(monkeypatch):
         api_key=secret_key,
         api_base="https://api.deepseek.com/v1",
     )
-    job_id = JobStore().create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="SESSION",
@@ -619,7 +619,7 @@ def _seed_job(req_overrides: dict | None = None) -> tuple[str, MagicMock]:
     """Seed a JobStore row + mock CreateMatchJobRequest sufficient for
     _run_and_persist to consume.
     """
-    job_id = JobStore().create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="publication",
@@ -667,7 +667,7 @@ def test_run_and_persist_marks_failed_on_cancellation(monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         asyncio.run(routes._run_and_persist(job_id, req, []))
 
-    job = JobStore().get_job(job_id)
+    job = job_store.get_job(job_id)
     assert job is not None
     assert job["status"] == "FAILED"
     assert job["error_message"] == "cancelled"
@@ -691,7 +691,7 @@ def test_run_and_persist_marks_failed_on_exception(monkeypatch):
     # Should NOT raise — generic exceptions are swallowed by design.
     asyncio.run(routes._run_and_persist(job_id, req, []))
 
-    job = JobStore().get_job(job_id)
+    job = job_store.get_job(job_id)
     assert job is not None
     assert job["status"] == "FAILED"
     assert job["error_message"] == "boom"
@@ -711,7 +711,7 @@ def test_run_and_persist_marks_completed_on_success(monkeypatch):
 
     asyncio.run(routes._run_and_persist(job_id, req, []))
 
-    job = JobStore().get_job(job_id)
+    job = job_store.get_job(job_id)
     assert job is not None
     assert job["status"] == "COMPLETED"
     assert job["progress"] == 100
@@ -726,18 +726,15 @@ def test_run_and_persist_marks_completed_on_success(monkeypatch):
 
 def test_update_job_fires_callback_on_status_transition(monkeypatch):
     """Genuine status flip (PENDING → PROCESSING) triggers a callback POST."""
-    from workflows.matcher import job_store as js_module
-
     captured: dict = {}
 
     def _fake_post(job_id: str, payload: dict) -> None:
         captured["job_id"] = job_id
         captured["payload"] = payload
 
-    monkeypatch.setattr(js_module, "_post_status_callback", _fake_post)
+    monkeypatch.setattr(job_store, "_post_status_callback", _fake_post)
 
-    store = JobStore()
-    job_id = store.create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="publication",
@@ -751,7 +748,7 @@ def test_update_job_fires_callback_on_status_transition(monkeypatch):
         model_name="gpt-4o-mini",
     )
 
-    store.update_job(job_id, status="PROCESSING", progress=10)
+    job_store.update_job(job_id, status="PROCESSING", progress=10)
 
     assert captured["job_id"] == job_id
     assert captured["payload"]["status"] == "PROCESSING"
@@ -762,17 +759,14 @@ def test_update_job_does_not_fire_callback_on_progress_only(monkeypatch):
     """Progress-only ticks don't trigger the callback — too noisy and the SSE
     stream already covers them.
     """
-    from workflows.matcher import job_store as js_module
-
     calls: list = []
 
     def _fake_post(job_id: str, payload: dict) -> None:
         calls.append((job_id, payload))
 
-    monkeypatch.setattr(js_module, "_post_status_callback", _fake_post)
+    monkeypatch.setattr(job_store, "_post_status_callback", _fake_post)
 
-    store = JobStore()
-    job_id = store.create_job(
+    job_id = job_store.create_job(
         user_id="u",
         instance_id="i",
         target_type="publication",
@@ -787,20 +781,20 @@ def test_update_job_does_not_fire_callback_on_progress_only(monkeypatch):
     )
 
     # Move to PROCESSING (one callback expected).
-    store.update_job(job_id, status="PROCESSING")
+    job_store.update_job(job_id, status="PROCESSING")
     assert len(calls) == 1
 
     # Several progress-only ticks — no extra callbacks.
-    store.update_job(job_id, progress=20)
-    store.update_job(job_id, progress=50)
-    store.update_job(job_id, progress=80)
+    job_store.update_job(job_id, progress=20)
+    job_store.update_job(job_id, progress=50)
+    job_store.update_job(job_id, progress=80)
     assert len(calls) == 1
 
     # Setting status to its current value is a no-op (no transition).
-    store.update_job(job_id, status="PROCESSING", progress=85)
+    job_store.update_job(job_id, status="PROCESSING", progress=85)
     assert len(calls) == 1
 
     # Terminal flip fires another callback.
-    store.update_job(job_id, status="COMPLETED", progress=100)
+    job_store.update_job(job_id, status="COMPLETED", progress=100)
     assert len(calls) == 2
     assert calls[1][1]["status"] == "COMPLETED"

--- a/apps/langgraph/tests/test_matcher_workflow.py
+++ b/apps/langgraph/tests/test_matcher_workflow.py
@@ -88,11 +88,10 @@ def _make_config(api_key: str = "sk-test-key", **overrides):
 
 
 def test_orchestrator_groups_queries_by_bu(monkeypatch):
-    fake_qo = MagicMock()
-    fake_qo.return_value.optimize_queries = MagicMock(
-        side_effect=lambda **kw: _fake_optimized(kw["bu"])
+    monkeypatch.setattr(
+        "workflows.matcher.job.optimize_queries",
+        lambda **kw: _fake_optimized(kw["bu"]),
     )
-    monkeypatch.setattr("workflows.matcher.job.QueryOptimizer", fake_qo)
 
     req = _make_req(
         [
@@ -128,16 +127,14 @@ def test_orchestrator_groups_queries_by_bu(monkeypatch):
 
 
 def test_orchestrator_passes_lm_config_to_optimizer(monkeypatch):
-    """QueryOptimizer must be instantiated with creds from RunnableConfig, not state."""
+    """optimize_queries must receive creds from RunnableConfig, not state."""
     captured: dict = {}
 
-    def fake_qo_ctor(**kwargs):
+    def fake_optimize(**kwargs):
         captured.update(kwargs)
-        instance = MagicMock()
-        instance.optimize_queries = MagicMock(side_effect=lambda **kw: _fake_optimized(kw["bu"]))
-        return instance
+        return _fake_optimized(kwargs["bu"])
 
-    monkeypatch.setattr("workflows.matcher.job.QueryOptimizer", fake_qo_ctor)
+    monkeypatch.setattr("workflows.matcher.job.optimize_queries", fake_optimize)
 
     req = _make_req([{"bu": "BU_A", "query": "q1"}])
     job_id = JobStore().create_job(

--- a/apps/langgraph/workflows/matcher/job.py
+++ b/apps/langgraph/workflows/matcher/job.py
@@ -17,7 +17,6 @@ traces, checkpoint stores, and any state.repr / pickle.
 from __future__ import annotations
 
 import logging
-import tempfile
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Annotated, Any, TypedDict
@@ -55,7 +54,6 @@ class JobState(TypedDict, total=False):
     results_by_bu: Annotated[dict[str, pd.DataFrame], _merge_dict]
     excel_bytes: bytes
     total_matches: int
-    index_dir: str
 
 
 def _lm_config_from(config: RunnableConfig) -> dict[str, Any]:
@@ -115,7 +113,6 @@ def orchestrator(state: JobState, config: RunnableConfig) -> dict:
     return {
         "queries_by_bu": queries_by_bu,
         "optimized": optimized,
-        "index_dir": tempfile.mkdtemp(prefix=f"lotus_{state['job_id']}_"),
     }
 
 
@@ -135,7 +132,6 @@ def assign_workers(state: JobState) -> list[Send]:
                 "optimized": opt,
                 "target_df": state["target_df"],
                 "req": state["req"],
-                "index_dir": state["index_dir"],
             },
         )
         for bu, opt in state["optimized"].items()

--- a/apps/langgraph/workflows/matcher/job.py
+++ b/apps/langgraph/workflows/matcher/job.py
@@ -31,7 +31,7 @@ from workflows.matcher._utils import redact_lm_config
 from workflows.matcher.excel_processor import ExcelProcessor
 from workflows.matcher.job_store import JobStore
 from workflows.matcher.lotus import build_text_column, rank_via_semops
-from workflows.matcher.query_optimizer import QueryOptimizer
+from workflows.matcher.query_optimizer import optimize_queries
 
 logger = logging.getLogger(__name__)
 job_store = JobStore()
@@ -94,13 +94,7 @@ def orchestrator(state: JobState, config: RunnableConfig) -> dict:
         if text:
             queries_by_bu[bu].append(text)
     queries_by_bu = dict(queries_by_bu)
-    optimizer = QueryOptimizer(
-        excel_processor=ExcelProcessor(),
-        model_provider=lm_config.get("provider"),
-        model_name=lm_config.get("model"),
-        api_key=lm_config.get("api_key"),
-        api_base=lm_config.get("api_base"),
-    )
+    excel_processor = ExcelProcessor()
     optimized: dict[str, Any] = {}
     total_bus = max(len(queries_by_bu), 1)
     for i, (bu, qs) in enumerate(queries_by_bu.items()):
@@ -108,10 +102,15 @@ def orchestrator(state: JobState, config: RunnableConfig) -> dict:
         job_store.update_job(
             state["job_id"], progress=progress, error_message=f"Optimizing queries: {bu}"
         )
-        optimized[bu] = optimizer.optimize_queries(
+        optimized[bu] = optimize_queries(
             bu=bu,
             queries=qs,
             target_type=req.target_type,
+            model_provider=lm_config.get("provider"),
+            model_name=lm_config.get("model"),
+            api_key=lm_config.get("api_key"),
+            api_base=lm_config.get("api_base"),
+            excel_processor=excel_processor,
         )
     job_store.update_job(state["job_id"], progress=30, query_data=_enriched(req.queries, optimized))
     return {

--- a/apps/langgraph/workflows/matcher/job.py
+++ b/apps/langgraph/workflows/matcher/job.py
@@ -27,14 +27,13 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import Send
 
+from workflows.matcher import job_store
 from workflows.matcher._utils import redact_lm_config
 from workflows.matcher.excel_processor import ExcelProcessor
-from workflows.matcher.job_store import JobStore
 from workflows.matcher.lotus import build_text_column, rank_via_semops
 from workflows.matcher.query_optimizer import optimize_queries
 
 logger = logging.getLogger(__name__)
-job_store = JobStore()
 
 
 def _merge_dict(left: dict, right: dict) -> dict:

--- a/apps/langgraph/workflows/matcher/job.py
+++ b/apps/langgraph/workflows/matcher/job.py
@@ -30,7 +30,7 @@ from langgraph.types import Send
 from workflows.matcher._utils import redact_lm_config
 from workflows.matcher.excel_processor import ExcelProcessor
 from workflows.matcher.job_store import JobStore
-from workflows.matcher.lotus import LotusMatcher
+from workflows.matcher.lotus import build_text_column, rank_via_semops
 from workflows.matcher.query_optimizer import QueryOptimizer
 
 logger = logging.getLogger(__name__)
@@ -147,16 +147,14 @@ def assign_workers(state: JobState) -> list[Send]:
 def rank_bu(ws: dict, config: RunnableConfig) -> dict:
     """Worker — runs LOTUS pipeline for one BU. Writes one entry into results_by_bu."""
     lm_config = _lm_config_from(config)
-    matcher = LotusMatcher()
-    target_df = matcher.build_text_column(ws["target_df"], ws["req"].target_type)
-    matches_df = matcher.run_pipeline(
+    target_df = build_text_column(ws["target_df"], ws["req"].target_type)
+    matches_df = rank_via_semops(
         df=target_df,
         query_text=ws["optimized"].optimized_query_en,
         query_name=ws["bu"],
         top_k=ws["req"].top_k,
         search_k=ws["req"].search_k,
         include_reasons=ws["req"].include_reasons,
-        index_dir=ws["index_dir"],
         progress_callback=lambda *_: None,
         model_provider=lm_config.get("provider"),
         model_name=lm_config.get("model"),

--- a/apps/langgraph/workflows/matcher/job_store.py
+++ b/apps/langgraph/workflows/matcher/job_store.py
@@ -26,14 +26,21 @@ logger = logging.getLogger(__name__)
 
 _CALLBACK_TIMEOUT_S = 5.0
 
+# Module-level state. Previously wrapped in a JobStore singleton with
+# __new__ + double-checked locking; the indirection added nothing because
+# the data and lock were already module-scope. Replace with a plain dict +
+# Lock — fewer lines, same semantics.
+_jobs: dict[str, dict] = {}
+_lock = threading.Lock()
+
 
 def _post_status_callback(job_id: str, payload: dict[str, Any]) -> None:
     """POST a status update to the Next.js internal route.
 
-    Synchronous urllib call — JobStore.update_job is invoked from worker
-    threads (asyncio.to_thread) and from inside the LangGraph node bodies,
-    so we cannot rely on an event loop being available. urllib in stdlib
-    avoids the httpx async/sync split entirely.
+    Synchronous urllib call — update_job is invoked from worker threads
+    (asyncio.to_thread) and from inside the LangGraph node bodies, so we
+    cannot rely on an event loop being available. urllib in stdlib avoids
+    the httpx async/sync split entirely.
 
     Best-effort: any error logs a warning and returns. Callback failure
     must NOT fail the matcher.
@@ -91,117 +98,105 @@ def _jsonify(payload: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-class JobStore:
-    """Thread-safe in-memory job storage."""
+def create_job(
+    user_id: str,
+    instance_id: str,
+    target_type: str,
+    top_k: int,
+    search_k: int,
+    include_reasons: bool,
+    query_data: list[dict],
+    query_count: int,
+    target_data: list[dict] = None,
+    model_provider: str = None,  # For query optimizer only
+    model_name: str = None,  # For query optimizer only
+) -> str:
+    """Create a new job and return its ID."""
+    job_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
 
-    _instance = None
-    _lock = threading.Lock()
+    with _lock:
+        _jobs[job_id] = {
+            "id": job_id,
+            "user_id": user_id,
+            "instance_id": instance_id,
+            "target_type": target_type,
+            "top_k": top_k,
+            "search_k": search_k,
+            "include_reasons": include_reasons,
+            "query_data": query_data,
+            "query_count": query_count,
+            "target_data": target_data or [],
+            "model_provider": model_provider or "google",
+            "model_name": model_name or "gemini-2.5-flash",
+            "status": "PENDING",
+            "progress": 0,
+            "match_count": 0,
+            "error_message": None,
+            "result_data": None,
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+            "completed_at": None,
+        }
 
-    def __new__(cls):
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._jobs = {}
-                    cls._instance._job_lock = threading.Lock()
-        return cls._instance
+    logger.info(f"Created job {job_id}")
+    return job_id
 
-    def create_job(
-        self,
-        user_id: str,
-        instance_id: str,
-        target_type: str,
-        top_k: int,
-        search_k: int,
-        include_reasons: bool,
-        query_data: list[dict],
-        query_count: int,
-        target_data: list[dict] = None,
-        model_provider: str = None,  # For query optimizer only
-        model_name: str = None,  # For query optimizer only
-    ) -> str:
-        """Create a new job and return its ID."""
-        job_id = str(uuid.uuid4())
-        now = datetime.now(timezone.utc)
 
-        with self._job_lock:
-            self._jobs[job_id] = {
-                "id": job_id,
-                "user_id": user_id,
-                "instance_id": instance_id,
-                "target_type": target_type,
-                "top_k": top_k,
-                "search_k": search_k,
-                "include_reasons": include_reasons,
-                "query_data": query_data,
-                "query_count": query_count,
-                "target_data": target_data or [],
-                "model_provider": model_provider or "google",
-                "model_name": model_name or "gemini-2.5-flash",
-                "status": "PENDING",
-                "progress": 0,
-                "match_count": 0,
-                "error_message": None,
-                "result_data": None,
-                "created_at": now,
-                "updated_at": now,
-                "started_at": None,
-                "completed_at": None,
-            }
+def get_job(job_id: str) -> Optional[dict]:
+    """Get job by ID."""
+    with _lock:
+        return _jobs.get(job_id)
 
-        logger.info(f"Created job {job_id}")
-        return job_id
 
-    def get_job(self, job_id: str) -> Optional[dict]:
-        """Get job by ID."""
-        with self._job_lock:
-            return self._jobs.get(job_id)
+def update_job(job_id: str, **kwargs) -> None:
+    """Update job fields.
 
-    def update_job(self, job_id: str, **kwargs) -> None:
-        """Update job fields.
+    Side effect: when `status` is in the update and the value actually
+    differs from the stored status (genuine transition, not idle re-set),
+    fire a best-effort callback to Next.js so Postgres mirrors the new
+    terminal/intermediate state. Progress-only ticks don't trigger the
+    callback — too noisy and the SSE stream already covers them.
+    """
+    status_changed = False
+    callback_payload: dict[str, Any] = {}
 
-        Side effect: when `status` is in the update and the value actually
-        differs from the stored status (genuine transition, not idle re-set),
-        fire a best-effort callback to Next.js so Postgres mirrors the new
-        terminal/intermediate state. Progress-only ticks don't trigger the
-        callback — too noisy and the SSE stream already covers them.
-        """
-        status_changed = False
-        callback_payload: dict[str, Any] = {}
+    with _lock:
+        job = _jobs.get(job_id)
+        if not job:
+            return
 
-        with self._job_lock:
-            job = self._jobs.get(job_id)
-            if not job:
-                return
+        new_status = kwargs.get("status")
+        if new_status is not None and new_status != job.get("status"):
+            status_changed = True
 
-            new_status = kwargs.get("status")
-            if new_status is not None and new_status != job.get("status"):
-                status_changed = True
-
-            job.update(kwargs)
-            job["updated_at"] = datetime.now(timezone.utc)
-
-            if status_changed:
-                callback_payload = {
-                    "status": job["status"],
-                    "progress": job.get("progress", 0),
-                    "match_count": job.get("match_count", 0),
-                    "error_message": job.get("error_message"),
-                    "started_at": job.get("started_at"),
-                    "completed_at": job.get("completed_at"),
-                }
+        job.update(kwargs)
+        job["updated_at"] = datetime.now(timezone.utc)
 
         if status_changed:
-            _post_status_callback(job_id, callback_payload)
+            callback_payload = {
+                "status": job["status"],
+                "progress": job.get("progress", 0),
+                "match_count": job.get("match_count", 0),
+                "error_message": job.get("error_message"),
+                "started_at": job.get("started_at"),
+                "completed_at": job.get("completed_at"),
+            }
 
-    def get_result_data(self, job_id: str) -> Optional[bytes]:
-        """Get result Excel bytes for a job."""
-        with self._job_lock:
-            job = self._jobs.get(job_id)
-            return job.get("result_data") if job else None
+    if status_changed:
+        _post_status_callback(job_id, callback_payload)
 
-    def get_target_data(self, job_id: str) -> Optional[list[dict]]:
-        """Get target data for a job."""
-        with self._job_lock:
-            job = self._jobs.get(job_id)
-            return job.get("target_data") if job else None
+
+def get_result_data(job_id: str) -> Optional[bytes]:
+    """Get result Excel bytes for a job."""
+    with _lock:
+        job = _jobs.get(job_id)
+        return job.get("result_data") if job else None
+
+
+def get_target_data(job_id: str) -> Optional[list[dict]]:
+    """Get target data for a job."""
+    with _lock:
+        job = _jobs.get(job_id)
+        return job.get("target_data") if job else None

--- a/apps/langgraph/workflows/matcher/lotus.py
+++ b/apps/langgraph/workflows/matcher/lotus.py
@@ -35,135 +35,117 @@ SEMOPS_API_URL = os.getenv("SEMOPS_API_URL", "http://localhost:2025")
 SEMOPS_RANK_TIMEOUT = float(os.getenv("SEMOPS_RANK_TIMEOUT", "1200"))
 
 
-class LotusMatcher:
-    """Wrapper for LOTUS semantic matching operations (HTTP-backed)."""
+def build_text_column(
+    df: pd.DataFrame,
+    target_type: str,
+) -> pd.DataFrame:
+    """
+    Build combined text column for semantic indexing.
 
-    def __init__(self):
-        # No local LOTUS state needed — operators run inside semops.
-        pass
+    Args:
+        df: DataFrame with session/publication data
+        target_type: 'SESSION' or 'PUBLICATION'
 
-    def configure(self):
-        """No-op: LOTUS is configured inside the semops service."""
-        pass
-
-    def build_text_column(
-        self,
-        df: pd.DataFrame,
-        target_type: str,
-    ) -> pd.DataFrame:
-        """
-        Build combined text column for semantic indexing.
-
-        Args:
-            df: DataFrame with session/publication data
-            target_type: 'SESSION' or 'PUBLICATION'
-
-        Returns:
-            DataFrame with 'match_text' column added
-        """
-        if target_type == "SESSION":
-            df = df.copy()
-            df["match_text"] = df.apply(
-                lambda r: (
-                    f"Title: {_safe_str(r.get('title'))} | "
-                    f"Type: {_safe_str(r.get('type'))} | "
-                    f"Abstract: {_truncate(_safe_str(r.get('abstract')), 500)} | "
-                    f"Topics: {_safe_str(r.get('topic'))} | "
-                    f"Speakers: {_safe_str(r.get('speaker'))} | "
-                    f"Affiliation: {_safe_str(r.get('affiliation'))} | "
-                    f"Technologies: {_safe_str(r.get('technology'))}"
-                ),
-                axis=1,
-            )
-        else:  # PUBLICATION
-            df = df.copy()
-            df["match_text"] = df.apply(
-                lambda r: (
-                    f"Title: {_safe_str(r.get('title'))} | "
-                    f"Authors: {_safe_str(r.get('authors'))} | "
-                    f"Abstract: {_truncate(_safe_str(r.get('abstract')), 500)} | "
-                    f"Keywords: {_safe_str(r.get('keywords'))} | "
-                    f"Research Topic: {_safe_str(r.get('research_topic'))} | "
-                    f"Affiliations: {_safe_str(r.get('affiliations'))}"
-                ),
-                axis=1,
-            )
-        return df
-
-    def run_pipeline(
-        self,
-        df: pd.DataFrame,
-        query_text: str,
-        query_name: str,
-        top_k: int = 50,
-        search_k: int = 350,
-        include_reasons: bool = True,
-        index_dir: str | None = None,
-        progress_callback: Callable[[int, str], None] | None = None,
-        *,
-        model_provider: str,
-        model_name: str,
-        api_key: str,
-        api_base: str | None = None,
-    ) -> pd.DataFrame:
-        """
-        Run the full LOTUS matching pipeline via the semops HTTP endpoint.
-
-        Sends candidates (with ``match_text`` already built) to
-        ``POST ${SEMOPS_API_URL}/api/operators/rank`` and returns the ranked
-        results as a DataFrame.
-
-        Args:
-            df: DataFrame with target data (must already have 'match_text' column)
-            query_text: Query text to match against
-            query_name: Name of the query (for logging)
-            top_k: Final number of matches to return
-            search_k: Embedding pre-filter size passed to semops
-            include_reasons: Whether to generate recommendation reasons
-            index_dir: Unused — indexing is now server-side in semops
-            progress_callback: Callback for progress updates (percent, message)
-
-        Returns:
-            DataFrame with top_k matches and optional recommendation_reason column
-        """
-        logger.info(f"Running pipeline for query: {query_name}")
-        logger.info(f"  Input: {len(df)} items, search_k={search_k}, top_k={top_k}")
-
-        if progress_callback:
-            progress_callback(10, "Sending candidates to semops for ranking...")
-
-        # Replace NaN with None before serialization. pandas keeps empty
-        # cells as float('nan'); the stdlib json encoder used by httpx
-        # rejects NaN (strict JSON), so the request never reaches semops
-        # and dies in build_request with
-        # "Out of range float values are not JSON compliant: nan".
-        #
-        # df.where(df.notna(), None) is unreliable across pandas versions
-        # (in 3.x None gets coerced back to NaN on numeric/object columns).
-        # pd.DataFrame.to_json natively converts NaN -> null, so round-
-        # tripping through to_json + json.loads guarantees a clean payload.
-        candidates = json.loads(df.to_json(orient="records"))
-
-        ranked_records = _rank_via_semops(
-            candidates=candidates,
-            query_text=query_text,
-            top_k=top_k,
-            search_k=search_k,
-            include_reasons=include_reasons,
-            model_provider=model_provider,
-            model_name=model_name,
-            api_key=api_key,
-            api_base=api_base,
+    Returns:
+        DataFrame with 'match_text' column added
+    """
+    if target_type == "SESSION":
+        df = df.copy()
+        df["match_text"] = df.apply(
+            lambda r: (
+                f"Title: {_safe_str(r.get('title'))} | "
+                f"Type: {_safe_str(r.get('type'))} | "
+                f"Abstract: {_truncate(_safe_str(r.get('abstract')), 500)} | "
+                f"Topics: {_safe_str(r.get('topic'))} | "
+                f"Speakers: {_safe_str(r.get('speaker'))} | "
+                f"Affiliation: {_safe_str(r.get('affiliation'))} | "
+                f"Technologies: {_safe_str(r.get('technology'))}"
+            ),
+            axis=1,
         )
+    else:  # PUBLICATION
+        df = df.copy()
+        df["match_text"] = df.apply(
+            lambda r: (
+                f"Title: {_safe_str(r.get('title'))} | "
+                f"Authors: {_safe_str(r.get('authors'))} | "
+                f"Abstract: {_truncate(_safe_str(r.get('abstract')), 500)} | "
+                f"Keywords: {_safe_str(r.get('keywords'))} | "
+                f"Research Topic: {_safe_str(r.get('research_topic'))} | "
+                f"Affiliations: {_safe_str(r.get('affiliations'))}"
+            ),
+            axis=1,
+        )
+    return df
 
-        if progress_callback:
-            progress_callback(100, "Complete")
 
-        return pd.DataFrame(ranked_records).reset_index(drop=True)
+def rank_via_semops(
+    *,
+    df: pd.DataFrame,
+    query_text: str,
+    query_name: str,
+    top_k: int = 50,
+    search_k: int = 350,
+    include_reasons: bool = True,
+    model_provider: str,
+    model_name: str,
+    api_key: str,
+    api_base: str | None = None,
+    progress_callback: Callable[[int, str], None] | None = None,
+) -> pd.DataFrame:
+    """
+    Run the full LOTUS matching pipeline via the semops HTTP endpoint.
 
-    def print_usage(self):
-        """No-op: usage statistics are tracked inside the semops service."""
-        pass
+    Sends candidates (with ``match_text`` already built) to
+    ``POST ${SEMOPS_API_URL}/api/operators/rank`` and returns the ranked
+    results as a DataFrame.
+
+    Args:
+        df: DataFrame with target data (must already have 'match_text' column)
+        query_text: Query text to match against
+        query_name: Name of the query (for logging)
+        top_k: Final number of matches to return
+        search_k: Embedding pre-filter size passed to semops
+        include_reasons: Whether to generate recommendation reasons
+        progress_callback: Callback for progress updates (percent, message)
+
+    Returns:
+        DataFrame with top_k matches and optional recommendation_reason column
+    """
+    logger.info(f"Running pipeline for query: {query_name}")
+    logger.info(f"  Input: {len(df)} items, search_k={search_k}, top_k={top_k}")
+
+    if progress_callback:
+        progress_callback(10, "Sending candidates to semops for ranking...")
+
+    # Replace NaN with None before serialization. pandas keeps empty
+    # cells as float('nan'); the stdlib json encoder used by httpx
+    # rejects NaN (strict JSON), so the request never reaches semops
+    # and dies in build_request with
+    # "Out of range float values are not JSON compliant: nan".
+    #
+    # df.where(df.notna(), None) is unreliable across pandas versions
+    # (in 3.x None gets coerced back to NaN on numeric/object columns).
+    # pd.DataFrame.to_json natively converts NaN -> null, so round-
+    # tripping through to_json + json.loads guarantees a clean payload.
+    candidates = json.loads(df.to_json(orient="records"))
+
+    ranked_records = _rank_via_semops(
+        candidates=candidates,
+        query_text=query_text,
+        top_k=top_k,
+        search_k=search_k,
+        include_reasons=include_reasons,
+        model_provider=model_provider,
+        model_name=model_name,
+        api_key=api_key,
+        api_base=api_base,
+    )
+
+    if progress_callback:
+        progress_callback(100, "Complete")
+
+    return pd.DataFrame(ranked_records).reset_index(drop=True)
 
 
 def _rank_via_semops(

--- a/apps/langgraph/workflows/matcher/query_optimizer.py
+++ b/apps/langgraph/workflows/matcher/query_optimizer.py
@@ -46,147 +46,130 @@ class QueryOptimizationResult:
     used_llm: bool = False
 
 
-class QueryOptimizer:
-    """Optimize grouped BU queries with Gemini."""
+def optimize_queries(
+    *,
+    bu: str,
+    queries: list[str],
+    target_type: str,
+    model_provider: str = "google",
+    model_name: str = "gemini-2.5-flash",
+    api_key: str | None = None,
+    api_base: str | None = None,
+    excel_processor: ExcelProcessor | None = None,
+) -> QueryOptimizationResult:
+    """Optimize all queries for one BU into a single clearer query.
 
-    def __init__(
-        self,
-        excel_processor: ExcelProcessor | None = None,
-        model_provider: str = "google",
-        model_name: str = "gemini-2.5-flash",
-        api_key: str | None = None,
-        api_base: str | None = None,
-    ):
-        self.excel_processor = excel_processor or ExcelProcessor()
-        self.model_provider = model_provider
-        self.model_name = model_name
-        self.api_base = api_base
-        self._client: genai.Client | None = None
+    Returns a deterministic-merge fallback if the BYOK key is missing or the
+    provider is unsupported (only Google Gemini is currently wired up for
+    LLM-based optimization).
+    """
+    excel_processor = excel_processor or ExcelProcessor()
+    normalized_queries = _dedupe_queries(queries)
+    fallback_native = _build_fallback_query(normalized_queries)
 
-        # BYOK only — no env fallback. If the caller wanted query
-        # optimization they must pass an api_key for a supported provider.
-        if model_provider == "google" and api_key:
-            self.api_key = api_key
-        else:
-            # Non-Google providers are not supported for LLM-based
-            # optimization yet; the matcher falls back to deterministic
-            # merge, which doesn't need a key.
-            self.api_key = None
-            if model_provider != "google":
-                logger.warning(
-                    "Query optimizer only supports Google Gemini. "
-                    f"Provider '{model_provider}' will use deterministic merge."
-                )
-            elif not api_key:
-                logger.warning(
-                    "Google provider selected but no BYOK key provided; "
-                    "query optimizer will fall back to deterministic merge."
-                )
-
-    def optimize_queries(
-        self,
-        bu: str,
-        queries: list[str],
-        target_type: str,
-    ) -> QueryOptimizationResult:
-        """Optimize all queries for one BU into a single clearer query."""
-        normalized_queries = self._dedupe_queries(queries)
-        fallback_native = self._build_fallback_query(normalized_queries)
-
-        if not normalized_queries:
-            return QueryOptimizationResult(
-                optimized_query_native="",
-                optimized_query_en="",
-                source_queries=[],
-            )
-
-        if not self.api_key:
-            logger.warning(
-                "Query optimizer has no GOOGLE_API_KEY configured. "
-                "Falling back to deterministic query merge."
-            )
-            return self._fallback_result(normalized_queries, fallback_native)
-
-        try:
-            client = self._get_client()
-            prompt = OPTIMIZER_USER_PROMPT_TEMPLATE.format(
-                target_type=target_type,
-                queries="\n".join(
-                    f"{index}. {query}" for index, query in enumerate(normalized_queries, start=1)
-                ),
-            )
-            response = client.models.generate_content(
-                model=self.model_name,
-                contents=f"{OPTIMIZER_SYSTEM_PROMPT.strip()}\n\n{prompt.strip()}",
-            )
-            optimized_native = (response.text or "").strip()
-            if not optimized_native:
-                logger.warning(
-                    "Query optimization returned no text for BU '%s'. Falling back to deterministic merge.",
-                    bu,
-                )
-                return self._fallback_result(normalized_queries, fallback_native)
-
-            if not optimized_native:
-                optimized_native = fallback_native
-
-            optimized_en = self.excel_processor._translate_to_english(optimized_native)
-
-            return QueryOptimizationResult(
-                optimized_query_native=optimized_native,
-                optimized_query_en=optimized_en,
-                source_queries=normalized_queries,
-                used_llm=True,
-            )
-        except Exception as exc:
-            logger.warning(
-                "Query optimization failed for BU '%s': %s. Falling back to deterministic merge.",
-                bu,
-                exc,
-            )
-            return self._fallback_result(normalized_queries, fallback_native)
-
-    def _fallback_result(
-        self,
-        queries: list[str],
-        fallback_native: str,
-    ) -> QueryOptimizationResult:
-        optimized_en = self.excel_processor._translate_to_english(fallback_native)
+    if not normalized_queries:
         return QueryOptimizationResult(
-            optimized_query_native=fallback_native,
-            optimized_query_en=optimized_en,
-            source_queries=queries,
-            used_llm=False,
+            optimized_query_native="",
+            optimized_query_en="",
+            source_queries=[],
         )
 
-    def _get_client(self) -> genai.Client:
-        if self._client is None:
-            self._client = genai.Client(api_key=self.api_key)
-        return self._client
+    # BYOK only — no env fallback. Non-Google providers are not supported
+    # for LLM-based optimization yet; fall back to deterministic merge.
+    effective_api_key: str | None = api_key
+    if model_provider != "google":
+        if api_key:
+            logger.warning(
+                "Query optimizer only supports Google Gemini. "
+                f"Provider '{model_provider}' will use deterministic merge."
+            )
+        effective_api_key = None
+    elif not api_key:
+        logger.warning(
+            "Google provider selected but no BYOK key provided; "
+            "query optimizer will fall back to deterministic merge."
+        )
 
-    @staticmethod
-    def _dedupe_queries(queries: list[str]) -> list[str]:
-        deduped: list[str] = []
-        seen: set[str] = set()
+    if not effective_api_key:
+        logger.warning(
+            "Query optimizer has no GOOGLE_API_KEY configured. "
+            "Falling back to deterministic query merge."
+        )
+        return _fallback_result(excel_processor, normalized_queries, fallback_native)
 
-        for raw_query in queries:
-            query = " ".join(str(raw_query).split()).strip()
-            if not query:
-                continue
+    try:
+        client = genai.Client(api_key=effective_api_key)
+        prompt = OPTIMIZER_USER_PROMPT_TEMPLATE.format(
+            target_type=target_type,
+            queries="\n".join(
+                f"{index}. {query}" for index, query in enumerate(normalized_queries, start=1)
+            ),
+        )
+        response = client.models.generate_content(
+            model=model_name,
+            contents=f"{OPTIMIZER_SYSTEM_PROMPT.strip()}\n\n{prompt.strip()}",
+        )
+        optimized_native = (response.text or "").strip()
+        if not optimized_native:
+            logger.warning(
+                "Query optimization returned no text for BU '%s'. Falling back to deterministic merge.",
+                bu,
+            )
+            return _fallback_result(excel_processor, normalized_queries, fallback_native)
 
-            key = query.casefold()
-            if key in seen:
-                continue
+        optimized_en = excel_processor._translate_to_english(optimized_native)
 
-            seen.add(key)
-            deduped.append(query)
+        return QueryOptimizationResult(
+            optimized_query_native=optimized_native,
+            optimized_query_en=optimized_en,
+            source_queries=normalized_queries,
+            used_llm=True,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Query optimization failed for BU '%s': %s. Falling back to deterministic merge.",
+            bu,
+            exc,
+        )
+        return _fallback_result(excel_processor, normalized_queries, fallback_native)
 
-        return deduped
 
-    @staticmethod
-    def _build_fallback_query(queries: list[str]) -> str:
-        if not queries:
-            return ""
-        if len(queries) == 1:
-            return queries[0]
-        return "\n".join(f"{index}. {query}" for index, query in enumerate(queries, start=1))
+def _fallback_result(
+    excel_processor: ExcelProcessor,
+    queries: list[str],
+    fallback_native: str,
+) -> QueryOptimizationResult:
+    optimized_en = excel_processor._translate_to_english(fallback_native)
+    return QueryOptimizationResult(
+        optimized_query_native=fallback_native,
+        optimized_query_en=optimized_en,
+        source_queries=queries,
+        used_llm=False,
+    )
+
+
+def _dedupe_queries(queries: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+
+    for raw_query in queries:
+        query = " ".join(str(raw_query).split()).strip()
+        if not query:
+            continue
+
+        key = query.casefold()
+        if key in seen:
+            continue
+
+        seen.add(key)
+        deduped.append(query)
+
+    return deduped
+
+
+def _build_fallback_query(queries: list[str]) -> str:
+    if not queries:
+        return ""
+    if len(queries) == 1:
+        return queries[0]
+    return "\n".join(f"{index}. {query}" for index, query in enumerate(queries, start=1))


### PR DESCRIPTION
Part of #154. Collapses LotusMatcher / QueryOptimizer / JobStore — all stateless or empty-shell classes — to module-level functions. Deletes the documented-unused index_dir parameter and its tempfile.mkdtemp leak. Net diff is negative.