### PR TITLE
refactor(semops): hygiene cleanup (#155 semops slice)

### DIFF
--- a/apps/semops/api/main.py
+++ b/apps/semops/api/main.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from api.routes import operators
+from api.routes import rank as rank_route
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ app.add_middleware(
 )
 
 # Routers
-app.include_router(operators.router, prefix="/api/operators", tags=["operators"])
+app.include_router(rank_route.router, prefix="/api/operators", tags=["operators"])
 
 
 @app.get("/health")

--- a/apps/semops/api/main.py
+++ b/apps/semops/api/main.py
@@ -20,12 +20,25 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
-    """Warm up the LOTUS rank pool at startup; shut it down cleanly at exit."""
+    """Warm up the LOTUS rank pool at startup; shut it down cleanly at exit.
+
+    Misconfigured ``SEMOPS_RANK_POOL_SIZE`` raises ``ValueError`` here and
+    is re-raised so the container fails to start with an obvious message
+    in logs (issue #155 fail-loud contract). Other warm-up failures
+    (e.g. transient HF model download hiccup) are still logged + swallowed
+    so the service can come up and serve traffic from a worker that
+    succeeds on the first real request.
+    """
     from services._pool import get_pool, shutdown_pool
 
     try:
         get_pool()  # Triggers init_worker() in each subprocess.
         logger.info("semops lifespan: rank pool warmed up")
+    except ValueError:
+        # Misconfigured env (e.g. SEMOPS_RANK_POOL_SIZE typo). Refuse to
+        # start so ops sees the error immediately in container logs.
+        logger.exception("semops lifespan: invalid configuration; refusing to start")
+        raise
     except Exception as exc:  # noqa: BLE001
         logger.warning("semops lifespan: pool warm-up failed: %s", exc)
     try:

--- a/apps/semops/api/routes/operators.py
+++ b/apps/semops/api/routes/operators.py
@@ -25,8 +25,18 @@ router = APIRouter()
 
 
 @router.post("/rank", response_model=RankResponse)
-async def rank(req: RankRequest):
-    """Run the LOTUS rank pipeline and return up to ``top_k`` results."""
+def rank(req: RankRequest):
+    """Run the LOTUS rank pipeline and return up to ``top_k`` results.
+
+    Defined as a sync ``def`` (not ``async def``) on purpose: the body
+    blocks on ``future.result()`` from the ProcessPoolExecutor pool, which
+    is a synchronous wait. With ``async def`` that block would happen on
+    the uvicorn event loop and serialize every concurrent rank request
+    through one thread. FastAPI runs sync handlers in starlette's
+    threadpool, so each incoming request gets its own thread and blocks
+    on its own future independently — concurrent ranks fan out across
+    pool workers as intended. See issue #155 (semops slice).
+    """
     logger.info(
         "rank request: provider=%s model=%s query_len=%d candidates=%d top_k=%d search_k=%d include_reasons=%s",
         req.lm_config.provider,

--- a/apps/semops/api/routes/rank.py
+++ b/apps/semops/api/routes/rank.py
@@ -1,9 +1,13 @@
 """
-Semantic operator routes.
+Rank route.
 
-Exposes the LOTUS rank pipeline directly. Workflow callers
-(apps/langgraph/workflows/{search,matcher,daily_digest}) invoke these over
-HTTP, passing per-request BYOK credentials in ``lm_config``.
+Exposes the LOTUS rank pipeline directly at ``POST /api/operators/rank``.
+Workflow callers (apps/langgraph/workflows/{search,matcher,daily_digest})
+invoke this over HTTP, passing per-request BYOK credentials in ``lm_config``.
+
+Module renamed from ``operators.py`` to ``rank.py`` (issue #155): semops
+exposes only this one endpoint, so naming the file after it is clearer.
+The HTTP path ``/api/operators/rank`` is kept for callers' compatibility.
 """
 
 import logging

--- a/apps/semops/services/_lotus_worker.py
+++ b/apps/semops/services/_lotus_worker.py
@@ -198,40 +198,57 @@ def _default_pipeline(
     ``run_rank``) so concurrent tenants never share LM state. Kept in this
     module — not imported from ``services.semantic_operators`` — so the
     subprocess stays thin.
+
+    Index directory hygiene
+    -----------------------
+    Each request gets its own scratch dir under
+    ``$LOTUS_INDEX_DIR/<pid>/<uuid>``. Previously every subprocess +
+    every request shared one fixed path (``/tmp/lotus_index``) — concurrent
+    FAISS writers contended on the same directory and serialized rank
+    work that was supposed to fan out across pool workers (see #155).
+    The dir is rmtree'd in a ``finally`` so disk doesn't accumulate
+    abandoned indexes, even if the pipeline raises.
     """
     import os
+    import shutil
+    import uuid
+
     import pandas as pd  # type: ignore
 
-    index_dir = os.getenv("LOTUS_INDEX_DIR", "/tmp/lotus_index")
+    base = os.getenv("LOTUS_INDEX_DIR", "/tmp/lotus_index")
+    index_dir = os.path.join(base, str(os.getpid()), uuid.uuid4().hex)
     os.makedirs(index_dir, exist_ok=True)
 
-    df = pd.DataFrame(candidates)
-    df = df.sem_index("match_text", index_dir)
-    shortlist_df = df.sem_search("match_text", query_text, K=search_k)
-    shortlist = shortlist_df.to_dict("records")[:search_k]
+    try:
+        df = pd.DataFrame(candidates)
+        df = df.sem_index("match_text", index_dir)
+        shortlist_df = df.sem_search("match_text", query_text, K=search_k)
+        shortlist = shortlist_df.to_dict("records")[:search_k]
 
-    topk_instruction = (
-        f"Given the following query:\n{query_text}\n\n"
-        f"Rank the items by relevance to this query. "
-        f"An item is more relevant if its {{match_text}} directly addresses, "
-        f"provides insights into, or offers solutions for the query's needs."
-    )
-    ranked_df = pd.DataFrame(shortlist).sem_topk(topk_instruction, K=top_k)
-    ranked = ranked_df.to_dict("records")[:top_k]
-
-    if include_reasons:
-        map_instruction = (
-            f"Given the query:\n{query_text}\n\n"
-            f"For the item described by: {{match_text}}\n\n"
-            f"请用中文写出2-3句简洁的推荐理由，说明为什么该条目与查询相关。要具体说明。"
+        topk_instruction = (
+            f"Given the following query:\n{query_text}\n\n"
+            f"Rank the items by relevance to this query. "
+            f"An item is more relevant if its {{match_text}} directly addresses, "
+            f"provides insights into, or offers solutions for the query's needs."
         )
-        mapped_df = pd.DataFrame(ranked).sem_map(map_instruction, suffix="recommendation_reason")
-        ranked = mapped_df.to_dict("records")
-        for item in ranked:
-            if not isinstance(item.get("recommendation_reason"), str) or not item["recommendation_reason"].strip():
-                item["recommendation_reason"] = "相关匹配。"
-    else:
-        for item in ranked:
-            item.pop("recommendation_reason", None)
+        ranked_df = pd.DataFrame(shortlist).sem_topk(topk_instruction, K=top_k)
+        ranked = ranked_df.to_dict("records")[:top_k]
 
-    return ranked
+        if include_reasons:
+            map_instruction = (
+                f"Given the query:\n{query_text}\n\n"
+                f"For the item described by: {{match_text}}\n\n"
+                f"请用中文写出2-3句简洁的推荐理由，说明为什么该条目与查询相关。要具体说明。"
+            )
+            mapped_df = pd.DataFrame(ranked).sem_map(map_instruction, suffix="recommendation_reason")
+            ranked = mapped_df.to_dict("records")
+            for item in ranked:
+                if not isinstance(item.get("recommendation_reason"), str) or not item["recommendation_reason"].strip():
+                    item["recommendation_reason"] = "相关匹配。"
+        else:
+            for item in ranked:
+                item.pop("recommendation_reason", None)
+
+        return ranked
+    finally:
+        shutil.rmtree(index_dir, ignore_errors=True)

--- a/apps/semops/services/_pool.py
+++ b/apps/semops/services/_pool.py
@@ -45,15 +45,31 @@ _pool: ProcessPoolExecutor | None = None
 
 
 def _pool_size() -> int:
+    """Resolve pool size from ``SEMOPS_RANK_POOL_SIZE`` env, or fall back.
+
+    Fail-loud contract: if the env var IS set but cannot be parsed as a
+    positive integer, raise ``ValueError`` so the semops process refuses
+    to start. Previously a typo (e.g. ``"8 "`` with a trailing space, or
+    ``"four"``) silently fell back to ``min(4, cpu_count())`` and ops
+    learned about it only when prod throughput stayed at the default.
+    See issue #155 (semops slice).
+
+    A truly unset (or empty-string) env still falls back to the default.
+    """
     env = os.getenv("SEMOPS_RANK_POOL_SIZE")
-    if env:
-        try:
-            n = int(env)
-            if n > 0:
-                return n
-        except ValueError:
-            logger.warning("invalid SEMOPS_RANK_POOL_SIZE=%r; falling back to default", env)
-    return min(4, os.cpu_count() or 1)
+    if env is None or env == "":
+        return min(4, os.cpu_count() or 1)
+    try:
+        n = int(env)
+    except ValueError as e:
+        raise ValueError(
+            f"SEMOPS_RANK_POOL_SIZE must be a positive integer, got: {env!r}"
+        ) from e
+    if n <= 0:
+        raise ValueError(
+            f"SEMOPS_RANK_POOL_SIZE must be a positive integer, got: {env!r}"
+        )
+    return n
 
 
 def _build_pool() -> ProcessPoolExecutor:

--- a/apps/semops/services/errors.py
+++ b/apps/semops/services/errors.py
@@ -15,7 +15,7 @@ pickle-safe types below before it leaves the worker. Each type:
   ``cls(message)`` is always valid (this is what pickle does on unpickle).
 * Has a stable, importable name so the parent process can ``except`` it.
 
-Mapped to HTTP statuses by ``api/routes/operators.py``:
+Mapped to HTTP statuses by ``api/routes/rank.py``:
 
     SemopsAuthError      -> 401  (BYOK key rejected)
     SemopsRateLimitError -> 429  (provider rate limit)

--- a/apps/semops/tests/test_operators_route.py
+++ b/apps/semops/tests/test_operators_route.py
@@ -5,14 +5,14 @@ Strategy
 The route imports the module-level ``rank`` from
 ``services.semantic_operators`` (aliased as ``run_rank`` to avoid colliding
 with the route handler's own ``rank`` name). We monkeypatch that bound
-reference on ``api.routes.operators`` so no real LOTUS call is ever made.
+reference on ``api.routes.rank`` so no real LOTUS call is ever made.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from api.routes import operators as operators_route
+from api.routes import rank as operators_route
 
 
 # ---------------------------------------------------------------------------

--- a/apps/semops/tests/test_semantic_operators.py
+++ b/apps/semops/tests/test_semantic_operators.py
@@ -13,6 +13,7 @@ in ``test_operators_route.py`` against the FastAPI ``TestClient``.
 
 from __future__ import annotations
 
+import os
 import sys
 from unittest.mock import MagicMock
 
@@ -497,3 +498,54 @@ def test_run_in_pool_does_not_rebuild_on_value_error(monkeypatch):
 
 def _raise_value_error_for_pool_test():
     raise ValueError("bad input")
+
+
+# ---------------------------------------------------------------------------
+# Issue #155 — SEMOPS_RANK_POOL_SIZE fail-loud parsing
+# ---------------------------------------------------------------------------
+
+
+def test_pool_size_fails_loud_on_unparseable_env(monkeypatch):
+    """A typo'd SEMOPS_RANK_POOL_SIZE must raise, not silently fall back.
+
+    Python's ``int()`` is lenient about leading/trailing whitespace, so we
+    pick a clearly-bad value (alpha) to exercise the fail-loud branch.
+    """
+    from services import _pool
+
+    monkeypatch.setenv("SEMOPS_RANK_POOL_SIZE", "four")
+    with pytest.raises(ValueError, match="positive integer"):
+        _pool._pool_size()
+
+
+def test_pool_size_fails_loud_on_non_positive(monkeypatch):
+    """Zero / negative values must raise, not silently fall back."""
+    from services import _pool
+
+    monkeypatch.setenv("SEMOPS_RANK_POOL_SIZE", "0")
+    with pytest.raises(ValueError, match="positive integer"):
+        _pool._pool_size()
+
+
+def test_pool_size_unset_uses_default(monkeypatch):
+    """An unset env still resolves to the default (no exception)."""
+    from services import _pool
+
+    monkeypatch.delenv("SEMOPS_RANK_POOL_SIZE", raising=False)
+    assert _pool._pool_size() == min(4, os.cpu_count() or 1)
+
+
+def test_pool_size_empty_string_uses_default(monkeypatch):
+    """Empty string env (e.g. unset shell var that still expanded) → default."""
+    from services import _pool
+
+    monkeypatch.setenv("SEMOPS_RANK_POOL_SIZE", "")
+    assert _pool._pool_size() == min(4, os.cpu_count() or 1)
+
+
+def test_pool_size_valid_positive_int(monkeypatch):
+    """Well-formed positive int still works."""
+    from services import _pool
+
+    monkeypatch.setenv("SEMOPS_RANK_POOL_SIZE", "8")
+    assert _pool._pool_size() == 8


### PR DESCRIPTION
Part of #155. Four small, surgical hygiene fixes scoped strictly to `apps/semops`.

## Summary

1. **Rank handler stops blocking the event loop** (`api/routes/rank.py`).
   The route was `async def` but blocked on `future.result()` from the
   ProcessPoolExecutor. That serialized every concurrent rank through the
   uvicorn event loop. Switched to a sync `def` so FastAPI runs it in
   starlette's threadpool — concurrent ranks now fan out across pool workers
   as intended. Picked Option A (sync handler) over Option B (`run_in_executor`)
   because the handler doesn't need to `await` anything else; sync `def` is
   the minimum-complexity fix.

2. **Per-request lotus scratch dir** (`services/_lotus_worker.py`).
   `_default_pipeline` now writes its FAISS index to
   `$LOTUS_INDEX_DIR/<pid>/<uuid>` and rmtree's it in `finally`. Previously
   every subprocess + every request shared one directory, which contributed
   to the rank-path serialization in #155.

3. **Fail-loud `SEMOPS_RANK_POOL_SIZE` parsing** (`services/_pool.py` +
   `api/main.py`). A non-empty env that does not parse as a positive
   integer now raises `ValueError`. The lifespan handler re-raises that
   specifically so the container refuses to start with the misconfiguration
   visible in container logs. Truly-unset and empty-string env still falls
   back to the default — that path is intentional and exercised in tests.

4. **(Optional) Rename `routes/operators.py` → `routes/rank.py`**. Kept this
   in scope because it was a clean ~10-line ripple: `git mv` + update one
   import in `api/main.py` + update the test import + two docstring
   references in `services/errors.py` and the test docstring. The HTTP path
   `/api/operators/rank` is unchanged, so callers in apps/langgraph need no
   changes.

## Out of scope (deferred / not touched)

- `apps/web/`, `apps/langgraph/` — handled in sister PRs
  (`refactor/matcher-web-hygiene`, `refactor/matcher-langgraph-hygiene`).
- LOTUS quicksort tuning — performance work, not hygiene.
- Per-tenant fairness — bigger architectural change tracked separately
  in #155.
- HuggingFace cache strategy — addressed in #163.

## Test plan

- [x] `pytest apps/semops/tests/` — 28 tests pass (5 new for the
      `_pool_size` fail-loud branches: typo'd value, zero, unset, empty
      string, well-formed int).
- [ ] `docker compose build semops` then `docker compose up -d semops` —
      `curl http://localhost:2025/health` returns 200.
- [ ] `curl -X POST http://localhost:2025/api/operators/rank -d '...'` with
      a fake key — should still return 401 with the normalized
      `SemopsAuthError` (proves the pool path runs end-to-end).
- [ ] After a rank request, `docker exec sparkflow-semops ls -la /tmp/lotus_index/`
      should either show pid-keyed subdirs OR be empty (cleanup ran in
      `finally` — both outcomes prove no shared-dir collision).
- [ ] Set `SEMOPS_RANK_POOL_SIZE=four` in `docker-compose.yml`, rebuild,
      `docker compose up semops` — container should fail to start with a
      clear error message in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)