### PR TITLE
refactor(matcher web): hygiene cleanup (#155 web slice)

### DIFF
--- a/apps/web/app/api/matcher/jobs/[jobId]/download/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/download/route.ts
@@ -46,9 +46,24 @@ export async function GET(
       return NextResponse.json({ error: "Result file not available yet" }, { status: 404 });
     }
 
+    // Defence in depth: resultFileKey is set by our own code today, but the
+    // Prisma column is a free-form string. Resolve and verify the path stays
+    // inside DATA_DIR so a poisoned key (`..\..\etc\passwd`) can't read
+    // arbitrary files off the host.
+    const resolvedDataDir = path.resolve(DATA_DIR);
+    const resolved = path.resolve(resolvedDataDir, job.resultFileKey);
+    if (
+      resolved !== resolvedDataDir &&
+      !resolved.startsWith(resolvedDataDir + path.sep)
+    ) {
+      console.error(
+        `[Matcher] Rejected out-of-DATA_DIR resultFileKey for job ${jobId}: ${job.resultFileKey}`,
+      );
+      return new Response("invalid path", { status: 400 });
+    }
+
     // Get stream from local file
-    const filePath = path.join(DATA_DIR, job.resultFileKey);
-    const stream = createReadStream(filePath);
+    const stream = createReadStream(resolved);
 
     // Convert Node.js Readable to web ReadableStream
     const webStream = new ReadableStream({

--- a/apps/web/app/api/matcher/jobs/[jobId]/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/route.ts
@@ -154,14 +154,31 @@ export async function DELETE(
       return NextResponse.json({ error: "Job not found" }, { status: 404 });
     }
 
-    // Delete the result file (if any). Query files no longer exist on disk —
-    // the wizard parses Excel client-side and we never persisted uploads.
+    // Fail closed: delete the result file FIRST and only delete the DB row if
+    // the unlink succeeded. Previously this used to swallow FS errors and
+    // delete the row anyway — that orphans the file on disk with no audit
+    // trail (the row was the only handle back to it). We have no retry queue
+    // for FS cleanup, so the simpler safe behaviour is to surface the failure.
+    //
+    // Query files no longer exist on disk — the wizard parses Excel
+    // client-side and we never persisted uploads. Only resultFileKey matters.
     if (job.resultFileKey) {
       try {
         await unlink(path.join(DATA_DIR, job.resultFileKey));
       } catch (fsErr) {
-        console.error(`[Matcher] Failed to delete file ${job.resultFileKey}:`, fsErr);
-        // Continue with DB record deletion regardless.
+        const code =
+          fsErr && typeof fsErr === "object" && "code" in fsErr
+            ? (fsErr as { code: unknown }).code
+            : null;
+        // ENOENT means the file is already gone — safe to proceed with DB
+        // delete; nothing to orphan.
+        if (code !== "ENOENT") {
+          console.error(`[Matcher] Failed to delete file ${job.resultFileKey}:`, fsErr);
+          return NextResponse.json(
+            { error: "Failed to delete result file; job not deleted" },
+            { status: 500 },
+          );
+        }
       }
     }
 

--- a/apps/web/app/api/matcher/jobs/[jobId]/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/route.ts
@@ -10,55 +10,11 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { mkdir, writeFile, unlink } from "fs/promises";
 import path from "path";
+import { fromWire } from "@/lib/matcher/wire";
 
 const WORKFLOWS_API_URL = process.env.NEXT_PUBLIC_WORKFLOWS_API_URL || "http://localhost:2027";
 
 const DATA_DIR = path.join(process.cwd(), "data");
-
-function normalizeMatcherQueryData(queryData: unknown) {
-  if (!Array.isArray(queryData)) {
-    return undefined;
-  }
-
-  return queryData.map((item) => {
-    const record = (item ?? {}) as Record<string, unknown>;
-    const rawFocuses = record.optimization_focuses ?? record.optimizationFocuses;
-    const optimizationFocuses = Array.isArray(rawFocuses)
-      ? rawFocuses.filter((focus): focus is string => typeof focus === "string" && focus.length > 0)
-      : [];
-
-    return {
-      id: typeof record.id === "string" ? record.id : "",
-      bu: typeof record.bu === "string" ? record.bu : "",
-      query: typeof record.query === "string" ? record.query : "",
-      rowIndex:
-        typeof record.rowIndex === "number"
-          ? record.rowIndex
-          : typeof record.row_index === "number"
-            ? record.row_index
-            : 0,
-      optimizedQueryNative:
-        typeof record.optimizedQueryNative === "string"
-          ? record.optimizedQueryNative
-          : typeof record.optimized_query_native === "string"
-            ? record.optimized_query_native
-            : undefined,
-      optimizedQueryEn:
-        typeof record.optimizedQueryEn === "string"
-          ? record.optimizedQueryEn
-          : typeof record.optimized_query_en === "string"
-            ? record.optimized_query_en
-            : undefined,
-      optimizationFocuses,
-      optimizerUsedLlm:
-        typeof record.optimizerUsedLlm === "boolean"
-          ? record.optimizerUsedLlm
-          : typeof record.optimizer_used_llm === "boolean"
-            ? record.optimizer_used_llm
-            : undefined,
-    };
-  });
-}
 
 export async function GET(
   _request: NextRequest,
@@ -98,21 +54,24 @@ export async function GET(
         const response = await fetch(`${WORKFLOWS_API_URL}/v1/workflows/matcher/jobs/${jobId}`);
         if (response.ok) {
           const matcherJob = await response.json();
-          const normalizedQueryData = normalizeMatcherQueryData(matcherJob.query_data);
+          const decoded = fromWire(matcherJob as Record<string, unknown>);
 
           // Update database with latest progress
           const isStarting =
-            job.status === "PENDING" && matcherJob.status && matcherJob.status !== "PENDING";
+            job.status === "PENDING" && decoded.status && decoded.status !== "PENDING";
           const updatedJob = await prisma.matchJob.update({
             where: { id: jobId },
             data: {
-              progress: matcherJob.progress ?? job.progress,
-              status: matcherJob.status ?? job.status,
-              matchCount: matcherJob.match_count ?? job.matchCount,
-              errorMessage: matcherJob.error_message ?? job.errorMessage,
-              queryData: normalizedQueryData ?? job.queryData ?? undefined,
+              progress: decoded.progress ?? job.progress,
+              status: decoded.status ?? job.status,
+              matchCount: decoded.matchCount ?? job.matchCount,
+              errorMessage: decoded.errorMessage ?? job.errorMessage,
+              // Prisma Json column accepts plain JSON; ParsedQuery is plain JSON in practice.
+              queryData: (decoded.queryData ?? job.queryData ?? undefined) as
+                | object
+                | undefined,
               startedAt: isStarting ? new Date() : job.startedAt,
-              completedAt: matcherJob.status === "COMPLETED" ? new Date() : job.completedAt,
+              completedAt: decoded.status === "COMPLETED" ? new Date() : job.completedAt,
             },
             include: {
               instance: {
@@ -125,7 +84,7 @@ export async function GET(
           });
 
           // If job just completed, download Excel from matcher and store locally
-          if (matcherJob.status === "COMPLETED" && !updatedJob.resultFileKey) {
+          if (decoded.status === "COMPLETED" && !updatedJob.resultFileKey) {
             try {
               const dlRes = await fetch(
                 `${WORKFLOWS_API_URL}/v1/workflows/matcher/jobs/${jobId}/download`,

--- a/apps/web/app/api/matcher/jobs/route.ts
+++ b/apps/web/app/api/matcher/jobs/route.ts
@@ -9,34 +9,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { resolveApiKey } from "@/lib/services/api-key-resolver";
+import { toWire } from "@/lib/matcher/wire";
 
 const WORKFLOWS_API_URL = process.env.NEXT_PUBLIC_WORKFLOWS_API_URL || "http://localhost:2027";
-
-// Convert camelCase to snake_case for matcher service
-function toSnakeCase(str: string): string {
-  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-}
-
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v) && v.constructor === Object;
-}
-
-function transformToSnakeCase(obj: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    const snakeKey = toSnakeCase(key);
-    if (Array.isArray(value)) {
-      result[snakeKey] = value.map((item) =>
-        isPlainObject(item) ? transformToSnakeCase(item) : item,
-      );
-    } else if (isPlainObject(value)) {
-      result[snakeKey] = transformToSnakeCase(value);
-    } else {
-      result[snakeKey] = value;
-    }
-  }
-  return result;
-}
 
 export async function POST(request: NextRequest) {
   try {
@@ -161,23 +136,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Build payload with all data
-    const payload: Record<string, unknown> = {
-      ...transformToSnakeCase({
-        instanceId,
-        targetType,
-        queries,
-        topK,
-        searchK,
-        includeReasons,
-        targetData,
-        modelProvider,
-        modelName,
-      }),
-      user_id: session.user.id,
-      api_key: apiKey,
-      api_base: apiBase ?? null,
-    };
+    // Build payload with all data — translate Prisma-shaped → wire-shaped via lib/matcher/wire.
+    const payload = toWire({
+      instanceId,
+      targetType,
+      queries: queries ?? [],
+      topK,
+      searchK,
+      includeReasons,
+      targetData,
+      modelProvider,
+      modelName,
+      userId: session.user.id,
+      apiKey,
+      apiBase: apiBase ?? null,
+    });
 
     console.log("[Matcher Jobs] Sending to matcher - model:", modelProvider, modelName);
 

--- a/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
+++ b/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
@@ -20,34 +20,51 @@ type WizardConfig = {
   includeReasons: boolean;
 };
 
+// Wizard state is a discriminated union on `kind`. Stages with different
+// fields don't share invalid intermediate shapes (e.g. `running` always has a
+// jobId; `results` always has a completedJob). Adding a new stage means adding
+// one variant + handler — no magic-number comparisons to grep for.
+type WizardKind = "upload" | "config" | "running" | "results";
+
+type CompletedJob = {
+  id: string;
+  status: string;
+  queryCount: number;
+  matchCount: number;
+  topK: number;
+  resultFileKey: string | null;
+  errorMessage: string | null;
+};
+
 type WizardState = {
-  step: number;
+  kind: WizardKind;
   config: WizardConfig | null;
   queries: ParsedQuery[] | null;
   jobId: string | null;
-  completedJob: {
-    id: string;
-    status: string;
-    queryCount: number;
-    matchCount: number;
-    topK: number;
-    resultFileKey: string | null;
-    errorMessage: string | null;
-  } | null;
+  completedJob: CompletedJob | null;
 };
+
+// Order matters: must match the visual progression in the breadcrumb.
+const KIND_ORDER: WizardKind[] = ["upload", "config", "running", "results"];
+
+function kindIndex(kind: WizardKind): number {
+  return KIND_ORDER.indexOf(kind);
+}
 
 export function MatcherWizard() {
   const router = useRouter();
   const tSteps = useTranslations("explore.toolbox.wizard.steps");
 
-  const DISPLAY_STEPS = [
-    { id: "upload", label: tSteps("upload"), internalStep: 0 },
-    { id: "config", label: tSteps("configure"), internalStep: 1 },
-    { id: "results", label: tSteps("results"), internalStep: 3 },
+  // Display order in breadcrumb omits "running" — that stage is rendered as
+  // "results active" so the user sees forward motion without a third tick.
+  const DISPLAY_STEPS: { id: WizardKind; label: string }[] = [
+    { id: "upload", label: tSteps("upload") },
+    { id: "config", label: tSteps("configure") },
+    { id: "results", label: tSteps("results") },
   ];
 
   const [state, setState] = useState<WizardState>({
-    step: 0,
+    kind: "upload",
     config: null,
     queries: null,
     jobId: null,
@@ -61,7 +78,7 @@ export function MatcherWizard() {
       console.log("[Wizard] Job completed:", job);
       setState((prev) => ({
         ...prev,
-        step: 3,
+        kind: "results",
         completedJob: {
           id: job.id,
           status: job.status,
@@ -78,12 +95,12 @@ export function MatcherWizard() {
     },
   });
 
-  // Step 0: Upload — preserve queries on re-entry
+  // Upload → Config — preserve queries on re-entry
   const handleUploadComplete = useCallback((queries: ParsedQuery[]) => {
-    setState((prev) => ({ ...prev, step: 1, queries }));
+    setState((prev) => ({ ...prev, kind: "config", queries }));
   }, []);
 
-  // Step 1: Config + Preview — start matching directly
+  // Config → Running — start matching directly
   const handleStartMatching = useCallback(
     async (config: WizardConfig, queries: ParsedQuery[]) => {
       try {
@@ -104,7 +121,7 @@ export function MatcherWizard() {
 
         setState((prev) => ({
           ...prev,
-          step: 2,
+          kind: "running",
           config,
           jobId: job.id,
         }));
@@ -115,13 +132,13 @@ export function MatcherWizard() {
     [createJob],
   );
 
-  // Step 2: Running - Cancel
+  // Running — Cancel
   const handleCancelJob = useCallback(async () => {
     if (!state.jobId) return;
     router.push("/explore/toolbox");
   }, [state.jobId, router]);
 
-  // Step 3: Results - Download
+  // Results — Download
   const handleDownload = useCallback(() => {
     if (!state.jobId) return;
     const downloadUrl = `/api/matcher/jobs/${state.jobId}/download`;
@@ -130,7 +147,7 @@ export function MatcherWizard() {
 
   const handleReset = useCallback(() => {
     setState({
-      step: 0,
+      kind: "upload",
       config: null,
       queries: null,
       jobId: null,
@@ -139,25 +156,29 @@ export function MatcherWizard() {
   }, []);
 
   const handleBack = useCallback(() => {
-    setState((prev) => ({ ...prev, step: Math.max(0, prev.step - 1) }));
+    setState((prev) => {
+      const idx = kindIndex(prev.kind);
+      if (idx <= 0) return prev;
+      return { ...prev, kind: KIND_ORDER[idx - 1] };
+    });
   }, []);
 
   const handleCancel = useCallback(() => {
     router.push("/explore");
   }, [router]);
 
-  // Navigate to a completed step — allowed from any step except running (2)
-  const handleStepClick = useCallback((targetInternalStep: number) => {
+  // Navigate to a completed step — allowed from any step except running
+  const handleStepClick = useCallback((targetKind: WizardKind) => {
     setState((prev) => {
-      if (prev.step === 2) return prev; // Can't navigate during running
-      if (targetInternalStep >= prev.step) return prev; // Can't jump forward
-      return { ...prev, step: targetInternalStep };
+      if (prev.kind === "running") return prev; // Can't navigate during running
+      if (kindIndex(targetKind) >= kindIndex(prev.kind)) return prev; // Can't jump forward
+      return { ...prev, kind: targetKind };
     });
   }, []);
 
   const renderStep = () => {
-    switch (state.step) {
-      case 0:
+    switch (state.kind) {
+      case "upload":
         return (
           <UploadStep
             onNext={handleUploadComplete}
@@ -165,7 +186,7 @@ export function MatcherWizard() {
             initialQueries={state.queries ?? undefined}
           />
         );
-      case 1:
+      case "config":
         return (
           <ConfigStep
             queries={state.queries ?? []}
@@ -175,9 +196,9 @@ export function MatcherWizard() {
             onCancel={handleCancel}
           />
         );
-      case 2:
+      case "running":
         return <RunningStep jobId={state.jobId!} progress={progress} onCancel={handleCancelJob} />;
-      case 3:
+      case "results":
         return (
           <ResultsStep job={state.completedJob} onDownload={handleDownload} onReset={handleReset} />
         );
@@ -189,18 +210,22 @@ export function MatcherWizard() {
   return (
     <Card className="overflow-hidden max-w-3xl mx-auto">
       <div className="flex items-center gap-1 px-6 py-3 bg-muted/30 border-b font-mono text-sm">
-        {DISPLAY_STEPS.map((step, index) => {
+        {DISPLAY_STEPS.map((displayStep, index) => {
+          // The "running" stage shows the "results" tick as active (we're
+          // headed there). Everything else is a direct kind comparison.
           const isActive =
-            step.internalStep === state.step || (state.step === 2 && step.internalStep === 3); // show results as active during running
+            displayStep.id === state.kind ||
+            (state.kind === "running" && displayStep.id === "results");
           const isPast =
-            step.internalStep < state.step && !(state.step === 2 && step.internalStep === 3);
-          const isClickable = isPast && state.step !== 2;
+            kindIndex(displayStep.id) < kindIndex(state.kind) &&
+            !(state.kind === "running" && displayStep.id === "results");
+          const isClickable = isPast && state.kind !== "running";
           return (
-            <div key={step.id} className="flex items-center gap-1">
+            <div key={displayStep.id} className="flex items-center gap-1">
               {index > 0 && <span className="text-muted-foreground/40 mx-2">/</span>}
               <button
                 type="button"
-                onClick={() => isClickable && handleStepClick(step.internalStep)}
+                onClick={() => isClickable && handleStepClick(displayStep.id)}
                 disabled={!isClickable}
                 className={cn(
                   "flex items-center gap-1 rounded px-1 -mx-1 transition-colors",
@@ -228,7 +253,7 @@ export function MatcherWizard() {
                         : "text-muted-foreground",
                   )}
                 >
-                  {step.label}
+                  {displayStep.label}
                 </span>
               </button>
             </div>

--- a/apps/web/components/explore/toolbox/matcher/query-preview-table.tsx
+++ b/apps/web/components/explore/toolbox/matcher/query-preview-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
+import { useState } from "react";
 import { Pencil, Check, X, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -14,152 +14,148 @@ interface QueryPreviewTableProps {
   className?: string;
 }
 
-export interface QueryPreviewTableHandle {
-  commitPendingEdit: () => ParsedQuery[] | null;
-}
+/**
+ * Editable preview table for parsed queries.
+ *
+ * Edits commit on input onBlur — no useImperativeHandle / forwardRef plumbing.
+ * The wizard's "Continue" button just reads the latest `queries` state from
+ * the parent.
+ */
+export function QueryPreviewTable({
+  queries,
+  onQueriesChange,
+  readOnly = false,
+  className,
+}: QueryPreviewTableProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValues, setEditValues] = useState({ bu: "", query: "" });
 
-export const QueryPreviewTable = forwardRef<QueryPreviewTableHandle, QueryPreviewTableProps>(
-  function QueryPreviewTable({ queries, onQueriesChange, readOnly = false, className }, ref) {
-    const [editingId, setEditingId] = useState<string | null>(null);
-    const [editValues, setEditValues] = useState({ bu: "", query: "" });
+  const handleEditStart = (q: ParsedQuery) => {
+    setEditingId(q.id);
+    setEditValues({ bu: q.bu, query: q.query });
+  };
 
-    const handleEditStart = (q: ParsedQuery) => {
-      setEditingId(q.id);
-      setEditValues({ bu: q.bu, query: q.query });
-    };
-
-    const commitPendingEdit = useCallback(() => {
-      if (!editingId) return null;
-
-      const updated = queries.map((q) =>
-        q.id === editingId ? { ...q, bu: editValues.bu, query: editValues.query } : q,
-      );
-
-      onQueriesChange?.(updated);
-      setEditingId(null);
-      return updated;
-    }, [editValues.bu, editValues.query, editingId, onQueriesChange, queries]);
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        commitPendingEdit,
-      }),
-      [commitPendingEdit],
+  const commitEdit = () => {
+    if (!editingId) return;
+    const updated = queries.map((q) =>
+      q.id === editingId ? { ...q, bu: editValues.bu, query: editValues.query } : q,
     );
+    onQueriesChange?.(updated);
+    setEditingId(null);
+  };
 
-    const handleEditSave = () => {
-      commitPendingEdit();
-    };
+  const handleEditCancel = () => {
+    setEditingId(null);
+  };
 
-    const handleEditCancel = () => {
-      setEditingId(null);
-    };
+  const handleDelete = (id: string) => {
+    if (!onQueriesChange) return;
+    const updated = queries.filter((q) => q.id !== id);
+    onQueriesChange(updated);
+  };
 
-    const handleDelete = (id: string) => {
-      if (!onQueriesChange) return;
-      const updated = queries.filter((q) => q.id !== id);
-      onQueriesChange(updated);
-    };
+  if (queries.length === 0) {
+    return <div className="text-center py-8 text-muted-foreground">No queries to display</div>;
+  }
 
-    if (queries.length === 0) {
-      return <div className="text-center py-8 text-muted-foreground">No queries to display</div>;
-    }
-
-    return (
-      <div className={cn("w-full overflow-auto", className)}>
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b bg-muted/50">
-              <th className="px-4 py-3 text-left font-medium w-12">#</th>
-              <th className="px-4 py-3 text-left font-medium w-32">BU</th>
-              <th className="px-4 py-3 text-left font-medium">Query</th>
-              {!readOnly && <th className="px-4 py-3 w-24"></th>}
+  return (
+    <div className={cn("w-full overflow-auto", className)}>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/50">
+            <th className="px-4 py-3 text-left font-medium w-12">#</th>
+            <th className="px-4 py-3 text-left font-medium w-32">BU</th>
+            <th className="px-4 py-3 text-left font-medium">Query</th>
+            {!readOnly && <th className="px-4 py-3 w-24"></th>}
+          </tr>
+        </thead>
+        <tbody>
+          {queries.map((query, index) => (
+            <tr
+              key={query.id}
+              className={cn(
+                "border-b transition-colors hover:bg-muted/30",
+                editingId === query.id && "bg-muted/50",
+              )}
+            >
+              <td className="px-4 py-3 text-muted-foreground">{index + 1}</td>
+              <td className="px-4 py-3">
+                {editingId === query.id ? (
+                  <input
+                    value={editValues.bu}
+                    onChange={(e) => setEditValues({ ...editValues, bu: e.target.value })}
+                    onBlur={commitEdit}
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  />
+                ) : (
+                  <span className="font-medium">{query.bu || "Unnamed"}</span>
+                )}
+              </td>
+              <td className="px-4 py-3">
+                {editingId === query.id ? (
+                  <Textarea
+                    value={editValues.query}
+                    onChange={(e) => setEditValues({ ...editValues, query: e.target.value })}
+                    onBlur={commitEdit}
+                    className="min-h-15 resize-none"
+                    rows={2}
+                  />
+                ) : (
+                  <p className="text-muted-foreground line-clamp-2">{query.query || "No query"}</p>
+                )}
+              </td>
+              {!readOnly && (
+                <td className="px-4 py-3">
+                  {editingId === query.id ? (
+                    <div className="flex gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        // onMouseDown so the click registers before the input's
+                        // onBlur fires — without it, blur would commit and
+                        // re-render before the click handler runs.
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={commitEdit}
+                        className="h-8 w-8"
+                      >
+                        <Check className="h-4 w-4 text-green-600" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={handleEditCancel}
+                        className="h-8 w-8"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="flex gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => handleEditStart(query)}
+                        className="h-8 w-8"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => handleDelete(query.id)}
+                        className="h-8 w-8 hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  )}
+                </td>
+              )}
             </tr>
-          </thead>
-          <tbody>
-            {queries.map((query, index) => (
-              <tr
-                key={query.id}
-                className={cn(
-                  "border-b transition-colors hover:bg-muted/30",
-                  editingId === query.id && "bg-muted/50",
-                )}
-              >
-                <td className="px-4 py-3 text-muted-foreground">{index + 1}</td>
-                <td className="px-4 py-3">
-                  {editingId === query.id ? (
-                    <input
-                      value={editValues.bu}
-                      onChange={(e) => setEditValues({ ...editValues, bu: e.target.value })}
-                      className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    />
-                  ) : (
-                    <span className="font-medium">{query.bu || "Unnamed"}</span>
-                  )}
-                </td>
-                <td className="px-4 py-3">
-                  {editingId === query.id ? (
-                    <Textarea
-                      value={editValues.query}
-                      onChange={(e) => setEditValues({ ...editValues, query: e.target.value })}
-                      className="min-h-15 resize-none"
-                      rows={2}
-                    />
-                  ) : (
-                    <p className="text-muted-foreground line-clamp-2">
-                      {query.query || "No query"}
-                    </p>
-                  )}
-                </td>
-                {!readOnly && (
-                  <td className="px-4 py-3">
-                    {editingId === query.id ? (
-                      <div className="flex gap-1">
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={handleEditSave}
-                          className="h-8 w-8"
-                        >
-                          <Check className="h-4 w-4 text-green-600" />
-                        </Button>
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={handleEditCancel}
-                          className="h-8 w-8"
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    ) : (
-                      <div className="flex gap-1">
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => handleEditStart(query)}
-                          className="h-8 w-8"
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => handleDelete(query.id)}
-                          className="h-8 w-8 hover:bg-destructive/10 hover:text-destructive"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    )}
-                  </td>
-                )}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    );
-  },
-);
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/components/explore/toolbox/matcher/steps/upload-step.tsx
+++ b/apps/web/components/explore/toolbox/matcher/steps/upload-step.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { v4 as uuidv4 } from "uuid";
 import { FileDropzone } from "../file-dropzone";
@@ -15,7 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { QueryPreviewTable, type QueryPreviewTableHandle } from "../query-preview-table";
+import { QueryPreviewTable } from "../query-preview-table";
 import type { ParsedQuery } from "@/lib/matcher/types";
 
 interface UploadStepProps {
@@ -54,7 +54,6 @@ export function UploadStep({ onNext, onCancel, initialQueries }: UploadStepProps
   const [queries, setQueries] = useState<ParsedQuery[]>(initialQueries ?? []);
   const [isParsing, setIsParsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const previewRef = useRef<QueryPreviewTableHandle>(null);
 
   const showPreview = queries.length > 0;
 
@@ -81,8 +80,9 @@ export function UploadStep({ onNext, onCancel, initialQueries }: UploadStepProps
   };
 
   const handleContinue = () => {
-    const nextQueries = previewRef.current?.commitPendingEdit() ?? queries;
-    onNext(nextQueries);
+    // Edits commit on input onBlur inside QueryPreviewTable, so the parent
+    // `queries` state is always current by the time the user clicks Continue.
+    onNext(queries);
   };
 
   return (
@@ -153,7 +153,7 @@ export function UploadStep({ onNext, onCancel, initialQueries }: UploadStepProps
             </Button>
           </div>
           <div className="border rounded-lg overflow-hidden max-h-125 overflow-y-auto">
-            <QueryPreviewTable ref={previewRef} queries={queries} onQueriesChange={setQueries} />
+            <QueryPreviewTable queries={queries} onQueriesChange={setQueries} />
           </div>
         </div>
       ) : (

--- a/apps/web/lib/matcher/hooks.ts
+++ b/apps/web/lib/matcher/hooks.ts
@@ -15,11 +15,20 @@ import {
 } from "./client";
 import type { CreateMatchJobInput, JobProgress, MatchJob, MatchJobStatus } from "./types";
 
-// Global registry to track SSE connections by jobId
-const sseConnections = new Map<string, EventSource>();
-
 /**
  * Hook for streaming job progress via SSE
+ *
+ * Lifecycle: the EventSource is owned by the effect — opened on mount, closed
+ * by the cleanup function. The previous module-level `sseConnections` Map only
+ * deleted on COMPLETED/FAILED/error and leaked on tab background, navigation
+ * away, dev hot-reload, or React unmount. Returning the cleanup from useEffect
+ * makes React responsible for the close, which is what we want.
+ *
+ * StrictMode double-mount note: with React.StrictMode the dev environment
+ * mounts → unmounts → remounts the effect synchronously. The first cycle's
+ * cleanup closes the EventSource before the second cycle opens its own —
+ * the workflows-API just gets two GETs and one stays open. We accept that
+ * over the leak.
  */
 export function useJobProgress(
   jobId: string | null,
@@ -34,7 +43,8 @@ export function useJobProgress(
   const [isLoading, setIsLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
 
-  // Store callbacks in refs
+  // Store callbacks in refs so the effect doesn't re-run when their identity
+  // changes — the wizard passes inline arrow functions on every render.
   const onCompleteRef = useRef(onComplete);
   const onErrorRef = useRef(onError);
   useEffect(() => {
@@ -52,20 +62,12 @@ export function useJobProgress(
       return;
     }
 
-    // Check if connection already exists
-    if (sseConnections.has(jobId)) {
-      console.log("[Matcher] SSE connection already exists for job:", jobId);
-      queueMicrotask(() => {
-        setIsConnected(true);
-        setIsLoading(true);
-      });
-      return;
-    }
-
     console.log("[Matcher] Creating SSE connection for job:", jobId);
     queueMicrotask(() => setIsLoading(true));
 
-    // Track if job completed successfully - used to ignore onerror after completion
+    // jobCompleted is checked in onerror to suppress the "connection closed"
+    // toast that EventSource fires after a clean server-side close on
+    // COMPLETED/FAILED. Closure-local; reset by remount.
     let jobCompleted = false;
 
     const eventSource = subscribeToJobProgress(
@@ -80,7 +82,6 @@ export function useJobProgress(
           jobCompleted = true;
           setIsLoading(false);
           eventSource.close();
-          sseConnections.delete(jobId);
 
           if (onCompleteRef.current) {
             getJob(jobId).then(onCompleteRef.current).catch(console.error);
@@ -89,7 +90,6 @@ export function useJobProgress(
           jobCompleted = true; // Mark as completed to prevent onerror from also firing
           setIsLoading(false);
           eventSource.close();
-          sseConnections.delete(jobId);
 
           // Defence-in-depth: pull the latest persisted row so the UI sees the
           // FAILED status + error_message even if the workflows-api → Next.js
@@ -111,7 +111,6 @@ export function useJobProgress(
         setIsConnected(false);
         setIsLoading(false);
         eventSource.close();
-        sseConnections.delete(jobId);
 
         if (onErrorRef.current) {
           onErrorRef.current(error);
@@ -119,12 +118,13 @@ export function useJobProgress(
       },
     );
 
-    // Store connection globally
-    sseConnections.set(jobId, eventSource);
-
-    // Don't close on cleanup - let the connection complete naturally
-    // This prevents React StrictMode double-effect issues
-    // The connection will close when job completes or errors
+    return () => {
+      // React owns the lifecycle: cleanup closes the EventSource on unmount,
+      // jobId change, or hot-reload. Idempotent — close() is a no-op once the
+      // success/error branch above has already closed.
+      console.log("[Matcher] SSE effect cleanup for job:", jobId);
+      eventSource.close();
+    };
   }, [jobId]);
 
   return {

--- a/apps/web/lib/matcher/wire.ts
+++ b/apps/web/lib/matcher/wire.ts
@@ -1,0 +1,233 @@
+/**
+ * Matcher Wire Contract
+ *
+ * Centralizes the snake_case ↔ camelCase translation between this Next.js app
+ * and the workflows-API (Python). Two shapes:
+ *
+ *   - Prisma-shaped (camelCase, what `lib/matcher/types.ts` exports) — what the
+ *     DB and React components see.
+ *   - Wire-shaped (snake_case) — what the workflows-API speaks.
+ *
+ * Use `toWire()` for outbound payloads (Next.js → workflows-API) and
+ * `fromWire()` for inbound payloads (workflows-API → Next.js).
+ *
+ * If a third shape ever shows up (a different upstream service, etc.), add a
+ * new pair here. Do **not** reinstate the inline transforms in route handlers.
+ */
+
+import type { MatchJobStatus, MatchTargetType, ParsedQuery } from "./types";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Wire-shaped types (snake_case). Kept independent of `types.ts` so a Prisma
+// rename never silently breaks the wire contract.
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface WireParsedQuery {
+  id: string;
+  bu: string;
+  query: string;
+  row_index: number;
+  optimized_query_native?: string;
+  optimized_query_en?: string;
+  optimization_focuses?: string[];
+  optimizer_used_llm?: boolean;
+}
+
+export interface WireJobProgress {
+  id: string;
+  status: MatchJobStatus;
+  progress: number;
+  error_message: string | null;
+  query_count: number;
+  match_count: number;
+  top_k?: number;
+}
+
+export interface WireMatchJob {
+  id: string;
+  user_id: string;
+  instance_id: string;
+  target_type: MatchTargetType;
+  top_k: number;
+  search_k: number;
+  include_reasons: boolean;
+  query_data: WireParsedQuery[] | null;
+  result_file_key: string | null;
+  status: MatchJobStatus;
+  progress: number;
+  error_message: string | null;
+  query_count: number;
+  match_count: number;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+/**
+ * Outbound POST payload to `/v1/workflows/matcher/jobs`. Includes auth/key
+ * bits that aren't part of any persisted shape.
+ */
+export interface WireCreateMatchJob {
+  instance_id: string;
+  target_type: MatchTargetType;
+  queries: WireParsedQuery[];
+  top_k: number;
+  search_k: number;
+  include_reasons: boolean;
+  target_data: Record<string, unknown>[];
+  model_provider: string;
+  model_name: string;
+  user_id: string;
+  api_key: string;
+  api_base: string | null;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Conversion helpers. Hand-rolled (no key-mangling reflection) so the compiler
+// catches drift between the Prisma shape and the wire shape.
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Convert a `ParsedQuery` (camelCase) to its wire form (snake_case).
+ */
+export function parsedQueryToWire(q: ParsedQuery): WireParsedQuery {
+  const wire: WireParsedQuery = {
+    id: q.id,
+    bu: q.bu,
+    query: q.query,
+    row_index: q.rowIndex,
+  };
+  if (q.optimizedQueryNative !== undefined) wire.optimized_query_native = q.optimizedQueryNative;
+  if (q.optimizedQueryEn !== undefined) wire.optimized_query_en = q.optimizedQueryEn;
+  if (q.optimizationFocuses !== undefined) wire.optimization_focuses = q.optimizationFocuses;
+  if (q.optimizerUsedLlm !== undefined) wire.optimizer_used_llm = q.optimizerUsedLlm;
+  return wire;
+}
+
+/**
+ * Convert a single wire-shaped query item back to camelCase. Tolerant: workflows-API
+ * sometimes echoes the original camelCase (when the optimizer no-ops), so we
+ * accept either spelling on the way in.
+ */
+export function parsedQueryFromWire(item: unknown): ParsedQuery {
+  const record = (item ?? {}) as Record<string, unknown>;
+
+  const rawFocuses = record.optimization_focuses ?? record.optimizationFocuses;
+  const optimizationFocuses = Array.isArray(rawFocuses)
+    ? rawFocuses.filter((focus): focus is string => typeof focus === "string" && focus.length > 0)
+    : [];
+
+  return {
+    id: typeof record.id === "string" ? record.id : "",
+    bu: typeof record.bu === "string" ? record.bu : "",
+    query: typeof record.query === "string" ? record.query : "",
+    rowIndex:
+      typeof record.rowIndex === "number"
+        ? record.rowIndex
+        : typeof record.row_index === "number"
+          ? record.row_index
+          : 0,
+    optimizedQueryNative:
+      typeof record.optimizedQueryNative === "string"
+        ? record.optimizedQueryNative
+        : typeof record.optimized_query_native === "string"
+          ? record.optimized_query_native
+          : undefined,
+    optimizedQueryEn:
+      typeof record.optimizedQueryEn === "string"
+        ? record.optimizedQueryEn
+        : typeof record.optimized_query_en === "string"
+          ? record.optimized_query_en
+          : undefined,
+    optimizationFocuses,
+    optimizerUsedLlm:
+      typeof record.optimizerUsedLlm === "boolean"
+        ? record.optimizerUsedLlm
+        : typeof record.optimizer_used_llm === "boolean"
+          ? record.optimizer_used_llm
+          : undefined,
+  };
+}
+
+/**
+ * Convert a list of wire-shaped queries back to camelCase, or `undefined` if the
+ * input isn't an array (workflows-API sometimes returns null pre-optimization).
+ */
+export function parsedQueriesFromWire(value: unknown): ParsedQuery[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(parsedQueryFromWire);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Top-level toWire / fromWire. These are the entry points the API routes use.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface ToWireInput {
+  instanceId: string;
+  targetType: MatchTargetType;
+  queries: ParsedQuery[];
+  topK: number;
+  searchK: number;
+  includeReasons: boolean;
+  targetData: Record<string, unknown>[];
+  modelProvider: string;
+  modelName: string;
+  userId: string;
+  apiKey: string;
+  apiBase: string | null;
+}
+
+/**
+ * Build the outbound `POST /v1/workflows/matcher/jobs` body from the
+ * Prisma-shaped wizard inputs.
+ */
+export function toWire(input: ToWireInput): WireCreateMatchJob {
+  return {
+    instance_id: input.instanceId,
+    target_type: input.targetType,
+    queries: input.queries.map(parsedQueryToWire),
+    top_k: input.topK,
+    search_k: input.searchK,
+    include_reasons: input.includeReasons,
+    target_data: input.targetData,
+    model_provider: input.modelProvider,
+    model_name: input.modelName,
+    user_id: input.userId,
+    api_key: input.apiKey,
+    api_base: input.apiBase,
+  };
+}
+
+/**
+ * Decode the workflows-API `GET /v1/workflows/matcher/jobs/{id}` response into
+ * the camelCase shape that Prisma + React want. Only fields the routes actually
+ * persist are returned — everything else is dropped.
+ */
+export function fromWire(wire: Record<string, unknown>): {
+  status?: MatchJobStatus;
+  progress?: number;
+  matchCount?: number;
+  errorMessage?: string | null;
+  queryData?: ParsedQuery[];
+} {
+  const out: ReturnType<typeof fromWire> = {};
+
+  if (typeof wire.status === "string") {
+    out.status = wire.status as MatchJobStatus;
+  }
+  if (typeof wire.progress === "number") {
+    out.progress = wire.progress;
+  }
+  if (typeof wire.match_count === "number") {
+    out.matchCount = wire.match_count;
+  }
+  if (wire.error_message === null || typeof wire.error_message === "string") {
+    out.errorMessage = wire.error_message;
+  }
+  const decoded = parsedQueriesFromWire(wire.query_data);
+  if (decoded) {
+    out.queryData = decoded;
+  }
+  return out;
+}


### PR DESCRIPTION
Part of #155. Tackles the apps/web hygiene items: wire-contract centralization, wizard discriminated union, SSE map → effect cleanup, drop imperative handle, path-traversal guard, DELETE fail-closed. Sister PRs landing in parallel for langgraph and semops slices.

## Commits (one per scope item)

1. `refactor(matcher web): centralize wire-contract types in lib/matcher/wire.ts` — moves the duplicated snake↔camel conversion (transformToSnakeCase in jobs/route.ts, normalizeMatcherQueryData in [jobId]/route.ts) into one module with explicit Wire* types kept independent of types.ts.
2. `refactor(matcher web): wizard state to discriminated union` — \`step: number\` (0/1/2/3) → \`kind: 'upload' | 'config' | 'running' | 'results'\`. The \`(state.step === 2 && step.internalStep === 3)\` guard collapses to a clean \`state.kind === 'running'\` check.
3. `refactor(matcher web): move SSE lifecycle into effect cleanup` — drops the module-level \`sseConnections\` Map. Returning the close() from \`useEffect\` makes React responsible for the lifecycle, fixing leaks on tab background, navigation away mid-PROCESSING, dev hot-reload.
4. `refactor(matcher web): drop useImperativeHandle from QueryPreviewTable` — edits commit on input \`onBlur\`; forwardRef + imperative handle plumbing deleted. Save/cancel buttons use \`onMouseDown=preventDefault\` so the click registers before the blur.
5. `fix(matcher web): path-traversal guard on download route` — \`path.resolve\` against DATA_DIR and reject if the resolved path escapes. Defence in depth — \`resultFileKey\` is set by our own code today, but the field is a free-form string in Prisma.
6. `fix(matcher web): fail-closed DELETE handler on FS errors` — return 500 if the result file can't be removed; ENOENT is treated as already-gone. Stops orphaning files on disk with no row to find them from.

## Test plan
- [x] \`cd apps/web && npx tsc --noEmit\` — clean
- [x] \`cd apps/web && npm run lint\` — clean
- [ ] Manual smoke: walk wizard upload → config → running → results in dev server (left for reviewer)
- [ ] Verify SSE stream closes when navigating away mid-job (DevTools Network panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)