### PR TITLE
fix(docker): retry npm fetches to survive corp-network ECONNRESET

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,6 +19,14 @@ FROM base AS builder
 # Real DATABASE_URL is supplied at runtime; this placeholder is build-only.
 ENV DATABASE_URL=postgresql://placeholder:placeholder@localhost:5432/placeholder
 
+# Corp networks frequently kill long npm fetches with ECONNRESET. Bump
+# retry count + timeouts so transient drops auto-recover instead of
+# failing the whole `docker compose build`.
+ENV NPM_CONFIG_FETCH_RETRIES=5
+ENV NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000
+ENV NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000
+ENV NPM_CONFIG_FETCH_TIMEOUT=600000
+
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 COPY prisma.config.ts ./
@@ -28,7 +36,17 @@ COPY prisma.config.ts ./
 # intercepting corporate networks fails the cert chain even with
 # NODE_EXTRA_CA_CERTS set. Disable verification just for this one fetch;
 # all subsequent stages run with normal cert validation.
-RUN npm ci && NODE_TLS_REJECT_UNAUTHORIZED=0 npx prisma generate
+#
+# `npm install --no-save @next/swc-linux-x64-gnu` is a workaround for
+# corp-network builds: if the lockfile was generated on macOS the linux
+# SWC binary isn't pinned, and `next build` falls back to fetching it
+# directly from Cloudflare (104.16.x.x), which most corp firewalls block.
+# Pulling it explicitly via the configured npm registry (the same one
+# `npm ci` just used) guarantees the binary is in node_modules before
+# `next build` looks for it. `--no-save` keeps package.json clean.
+RUN npm ci && \
+    npm install --no-save --no-audit @next/swc-linux-x64-gnu && \
+    NODE_TLS_REJECT_UNAUTHORIZED=0 npx prisma generate
 
 COPY . .
 

--- a/apps/web/Dockerfile.worker
+++ b/apps/web/Dockerfile.worker
@@ -19,6 +19,15 @@ RUN if [ -s /tmp/corporate-ca.crt ]; then \
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 FROM base AS deps
+
+# Corp networks frequently kill long npm fetches with ECONNRESET. Bump
+# retry count + timeouts so transient drops auto-recover instead of
+# failing the whole build.
+ENV NPM_CONFIG_FETCH_RETRIES=5
+ENV NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000
+ENV NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000
+ENV NPM_CONFIG_FETCH_TIMEOUT=600000
+
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 # NODE_TLS_REJECT_UNAUTHORIZED=0 scoped to prisma generate only — Prisma


### PR DESCRIPTION
Server `docker compose build` was dying mid-`npm ci` / `npm install @next/swc-linux-x64-gnu` with `npm error code ECONNRESET`. The corp proxy intermittently kills long-lived TLS connections to the npm registry, and npm's default retry policy (2 retries, 60 s max) isn't enough to ride out the drops.

Bump fetch retries + timeouts in both web and worker builder stages so transient resets auto-recover. Also brings the SWC linux preinstall fix from main into this branch so the merge doesn't regress.