### PR TITLE
fix(matcher): tame SSE error handling, recover from orphaned jobs

### DIFF
--- a/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
+++ b/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
@@ -149,7 +149,10 @@ export function MatcherWizard() {
       }));
     },
     onError: (error) => {
-      console.error("[Wizard] Job error:", error);
+      // Demoted to warn so an SSE drop / workflows-api restart in dev
+      // doesn't pop the Next 16 error overlay. The job itself is tracked
+      // in Postgres; refresh re-hydrates the latest persisted status.
+      console.warn("[Wizard] Job stream error:", error);
     },
   });
 

--- a/apps/web/lib/matcher/client.ts
+++ b/apps/web/lib/matcher/client.ts
@@ -81,14 +81,41 @@ export function subscribeToJobProgress(
     }
   };
 
-  eventSource.onerror = () => {
-    // Note: onerror fires when connection closes, which is normal after job completion.
-    // The onError callback will be ignored by hooks.ts if the job already completed.
-    console.log("[matcher] SSE connection closed");
-    if (onError) {
-      onError(new Error("SSE connection error"));
+  // The "error" listener catches BOTH connection-level errors (no .data)
+  // AND server-sent named "error" events (with JSON .data). workflows-api
+  // emits the latter when its in-memory job_store has lost the job, e.g.
+  // after a workflows-api restart while Postgres still has the row. We
+  // must close() in that case — otherwise EventSource auto-reconnects
+  // forever and burns the upstream.
+  eventSource.addEventListener("error", (event) => {
+    const data = (event as MessageEvent).data;
+    if (typeof data === "string" && data.length > 0) {
+      let parsed: unknown = null;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        /* fall through to generic close */
+      }
+      const message =
+        parsed && typeof parsed === "object" && parsed !== null && "error" in parsed
+          ? String((parsed as { error: unknown }).error)
+          : "Job stream ended";
+      console.warn("[matcher] SSE upstream error:", message);
+      eventSource.close();
+      if (onError) onError(new Error(message));
+      return;
     }
-  };
+    // Connection-level error. EventSource auto-reconnects unless
+    // readyState === CLOSED — only surface as a real failure once it's
+    // permanently dead, otherwise we'd tear down the consumer on every
+    // reconnection blip and pop the Next 16 dev overlay.
+    if (eventSource.readyState !== EventSource.CLOSED) {
+      console.warn("[matcher] SSE transient error, awaiting auto-reconnect");
+      return;
+    }
+    console.warn("[matcher] SSE connection closed");
+    if (onError) onError(new Error("SSE connection closed"));
+  });
 
   return eventSource;
 }

--- a/apps/web/lib/matcher/hooks.ts
+++ b/apps/web/lib/matcher/hooks.ts
@@ -107,7 +107,11 @@ export function useJobProgress(
           console.log("[Matcher] SSE connection closed after completion (expected)");
           return;
         }
-        console.error("[Matcher] SSE error:", error);
+        // console.warn (not error) so the Next.js dev overlay doesn't pop on
+        // ordinary SSE drops — workflows-api restart, brief network hiccup,
+        // dev hot-reload of the proxy route. The job itself is still tracked
+        // in Postgres; the wizard can recover by re-fetching.
+        console.warn("[Matcher] SSE error:", error);
         setIsConnected(false);
         setIsLoading(false);
         eventSource.close();


### PR DESCRIPTION
After the URL-persistence change, refreshing onto a ?jobId=... whose in-memory state on workflows-api had been wiped (e.g. by a workflows-api restart while Postgres still showed PROCESSING) produced two bad behaviours:

1. workflows-api emits `event: error\ndata: {"error":"Job not found"}` then closes; the browser EventSource auto-reconnects forever, hitting the same "Job not found" each time and burning the upstream.
2. The previous onerror handler unconditionally produced a console.error `SSE connection error`, which Next 16's dev overlay surfaces as a blocking error popup on every reconnection blip — including the harmless ones during workflows-api hot-reload.

Fix:
- Replace `eventSource.onerror = ...` with `addEventListener("error", ...)` so server-sent NAMED "error" events (those that carry .data) are caught alongside connection-level errors. When a server-sent error arrives, close() the EventSource and surface the upstream message — no more reconnect storm.
- Connection-level errors now check `readyState === CLOSED` before treating them as terminal; transient drops just log a warn and let EventSource auto-reconnect per spec.
- Demote the SSE/job-stream error log lines from `console.error` to `console.warn` in hooks.ts and matcher-wizard.tsx so the dev overlay stops popping for a recoverable stream blip — the job itself is still tracked in Postgres and re-hydrates on refresh.