### PR TITLE
fix(matcher): auto-recover from orphaned PROCESSING rows

### DIFF
--- a/apps/web/app/api/matcher/jobs/[jobId]/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/route.ts
@@ -52,6 +52,26 @@ export async function GET(
     if (job.status === "PENDING" || job.status === "PROCESSING") {
       try {
         const response = await fetch(`${WORKFLOWS_API_URL}/v1/workflows/matcher/jobs/${jobId}`);
+        if (response.status === 404) {
+          // Orphan: workflows-api restarted (or the in-memory store was
+          // wiped) while Postgres still showed PENDING/PROCESSING. Flip
+          // the row to FAILED so the single-flight guard releases and the
+          // wizard renders a terminal state instead of spinning forever.
+          const failedJob = await prisma.matchJob.update({
+            where: { id: jobId },
+            data: {
+              status: "FAILED",
+              errorMessage: "Matcher service restarted; please retry this job.",
+              completedAt: new Date(),
+            },
+            include: {
+              instance: {
+                select: { name: true, venue: { select: { name: true } } },
+              },
+            },
+          });
+          return NextResponse.json(failedJob);
+        }
         if (response.ok) {
           const matcherJob = await response.json();
           const decoded = fromWire(matcherJob as Record<string, unknown>);

--- a/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
+++ b/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
@@ -153,6 +153,36 @@ export function MatcherWizard() {
       // doesn't pop the Next 16 error overlay. The job itself is tracked
       // in Postgres; refresh re-hydrates the latest persisted status.
       console.warn("[Wizard] Job stream error:", error);
+      // Re-fetch from the server so we don't leave the user spinning at
+      // the running step. The GET endpoint flips orphaned rows
+      // (workflows-api restarted; in-memory store wiped) to FAILED, so
+      // this transition lands the wizard at the results step with the
+      // upstream error message and unlocks the single-flight guard.
+      setState((prev) => {
+        if (prev.kind !== "running" || !prev.jobId) return prev;
+        const jobId = prev.jobId;
+        getJob(jobId)
+          .then((job) => {
+            if (!TERMINAL_STATUSES.has(job.status)) return;
+            setState((p) => ({
+              ...p,
+              kind: "results",
+              completedJob: {
+                id: job.id,
+                status: job.status,
+                queryCount: job.queryCount,
+                matchCount: job.matchCount,
+                topK: job.topK,
+                resultFileKey: job.resultFileKey,
+                errorMessage: job.errorMessage,
+              },
+            }));
+          })
+          .catch((err) => {
+            console.warn("[Wizard] Failed to refetch after stream error:", err);
+          });
+        return prev;
+      });
     },
   });
 


### PR DESCRIPTION
After workflows-api restarts, its in-memory job_store is empty but Postgres still shows PENDING/PROCESSING for the just-killed jobs. That left the user permanently stuck:
- single-flight guard returned 409 for every new submit
- the wizard hydrated to the dead jobId, opened SSE, got "Job not found", and spun forever on the running step

Two-sided fix:

- GET /api/matcher/jobs/[jobId]: when workflows-api 404s a non-terminal Postgres row, flip the row to FAILED with errorMessage explaining the matcher service restarted. This unblocks the inflight check on the very next refresh.

- Wizard SSE onError: refetch the job (which now returns FAILED via the path above) and transition to the results step. No more eternal spinner — the user lands on a clear failed-state UI and can start a new job.