### PR TITLE
feat(matcher): real Cancel Job button, separate from Run in Background

### DIFF
--- a/apps/web/app/api/matcher/jobs/[jobId]/cancel/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/cancel/route.ts
@@ -1,0 +1,73 @@
+/**
+ * Cancel a running match job.
+ *
+ * Distinct from `DELETE /api/matcher/jobs/[jobId]`, which wipes the row
+ * from history. Cancel forwards the request to workflows-api so its
+ * in-memory status flips to CANCELLED (best-effort — the LOTUS rank
+ * thread can't actually be interrupted, but the in-memory flag prevents
+ * any further status callbacks from clobbering Postgres) and then
+ * updates the Postgres row to CANCELLED. The row stays for history.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const WORKFLOWS_API_URL = process.env.NEXT_PUBLIC_WORKFLOWS_API_URL || "http://localhost:2027";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { jobId } = await params;
+
+    const job = await prisma.matchJob.findFirst({
+      where: { id: jobId, userId: session.user.id },
+      select: { status: true },
+    });
+    if (!job) {
+      return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+    if (job.status === "COMPLETED" || job.status === "CANCELLED" || job.status === "FAILED") {
+      return NextResponse.json(
+        { error: `Job already in terminal state: ${job.status}` },
+        { status: 400 },
+      );
+    }
+
+    // Forward to workflows-api. Best-effort: a 404 means workflows-api
+    // already lost the in-memory job (orphan), but the Postgres row
+    // still needs flipping so the single-flight guard releases.
+    try {
+      await fetch(`${WORKFLOWS_API_URL}/v1/workflows/matcher/jobs/${jobId}`, {
+        method: "DELETE",
+      });
+    } catch (err) {
+      console.warn("[Matcher Cancel] workflows-api forward failed:", err);
+    }
+
+    const updated = await prisma.matchJob.update({
+      where: { id: jobId },
+      data: {
+        status: "CANCELLED",
+        completedAt: new Date(),
+      },
+      include: {
+        instance: {
+          select: { name: true, venue: { select: { name: true } } },
+        },
+      },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Cancel job error:", error);
+    return NextResponse.json({ error: "Failed to cancel job" }, { status: 500 });
+  }
+}

--- a/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
+++ b/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
@@ -10,7 +10,7 @@ import { ConfigStep } from "./steps/config-step";
 import { RunningStep } from "./steps/running-step";
 import { ResultsStep } from "./steps/results-step";
 import { useJobProgress, useMatchJob } from "@/lib/matcher/hooks";
-import { downloadJobResult, getJob, InflightJobError } from "@/lib/matcher/client";
+import { cancelJob, downloadJobResult, getJob, InflightJobError } from "@/lib/matcher/client";
 import type { ParsedQuery, MatchTargetType } from "@/lib/matcher/types";
 
 const TERMINAL_STATUSES = new Set(["COMPLETED", "FAILED", "CANCELLED"]);
@@ -239,11 +239,36 @@ export function MatcherWizard() {
     [createJob, router],
   );
 
-  // Running — Cancel
+  // Running — actively stop the job. Forwards to workflows-api so the
+  // in-memory status flips to CANCELLED, then surfaces the cancelled row
+  // at the results step. Distinct from "Run in Background" which just
+  // navigates away while the job continues server-side.
   const handleCancelJob = useCallback(async () => {
     if (!state.jobId) return;
+    try {
+      const job = await cancelJob(state.jobId);
+      setState((prev) => ({
+        ...prev,
+        kind: "results",
+        completedJob: {
+          id: job.id,
+          status: job.status,
+          queryCount: job.queryCount,
+          matchCount: job.matchCount,
+          topK: job.topK,
+          resultFileKey: job.resultFileKey,
+          errorMessage: job.errorMessage,
+        },
+      }));
+    } catch (err) {
+      console.warn("[Wizard] Failed to cancel job:", err);
+    }
+  }, [state.jobId]);
+
+  // Running — leave the job running server-side, just navigate away.
+  const handleRunInBackground = useCallback(() => {
     router.push("/explore/toolbox");
-  }, [state.jobId, router]);
+  }, [router]);
 
   // Results — Download
   const handleDownload = useCallback(async () => {
@@ -311,7 +336,14 @@ export function MatcherWizard() {
           />
         );
       case "running":
-        return <RunningStep jobId={state.jobId!} progress={progress} onCancel={handleCancelJob} />;
+        return (
+          <RunningStep
+            jobId={state.jobId!}
+            progress={progress}
+            onCancel={handleCancelJob}
+            onRunInBackground={handleRunInBackground}
+          />
+        );
       case "results":
         return (
           <ResultsStep job={state.completedJob} onDownload={handleDownload} onReset={handleReset} />

--- a/apps/web/components/explore/toolbox/matcher/steps/running-step.tsx
+++ b/apps/web/components/explore/toolbox/matcher/steps/running-step.tsx
@@ -9,6 +9,7 @@ interface RunningStepProps {
   jobId: string;
   progress: JobProgress | null;
   onCancel: () => void;
+  onRunInBackground: () => void;
 }
 
 const statusConfig: Record<MatchJobStatus, { label: string; color: string }> = {
@@ -19,7 +20,7 @@ const statusConfig: Record<MatchJobStatus, { label: string; color: string }> = {
   CANCELLED: { label: "Cancelled", color: "text-muted-foreground" },
 };
 
-export function RunningStep({ progress, onCancel }: RunningStepProps) {
+export function RunningStep({ progress, onCancel, onRunInBackground }: RunningStepProps) {
   const status = progress?.status || "PENDING";
   const progressValue = progress?.progress || 0;
   const isTerminal = ["COMPLETED", "FAILED", "CANCELLED"].includes(status);
@@ -62,17 +63,26 @@ export function RunningStep({ progress, onCancel }: RunningStepProps) {
         </p>
       )}
 
-      {/* Close / Run-in-background button — onCancel just navigates away;
-          the job keeps running on the workflows-api regardless. */}
-      <div className="flex justify-end pt-2">
-        <Button
-          variant={isTerminal ? "default" : "outline"}
-          onClick={onCancel}
-          disabled={status === "CANCELLED"}
-          size="sm"
-        >
-          {isTerminal ? "Close" : "Run in Background"}
-        </Button>
+      {/* Two distinct actions during running:
+          - "Cancel Job" actively stops the work (forwards to workflows-api,
+            flips Postgres to CANCELLED, lands user at the results step).
+          - "Run in Background" just navigates away; the server-side job
+            keeps running and the user can return via the URL or History. */}
+      <div className="flex justify-end gap-2 pt-2">
+        {isTerminal ? (
+          <Button variant="default" onClick={onRunInBackground} size="sm">
+            Close
+          </Button>
+        ) : (
+          <>
+            <Button variant="outline" onClick={onCancel} size="sm">
+              Cancel Job
+            </Button>
+            <Button variant="default" onClick={onRunInBackground} size="sm">
+              Run in Background
+            </Button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/lib/matcher/client.ts
+++ b/apps/web/lib/matcher/client.ts
@@ -122,15 +122,21 @@ export function subscribeToJobProgress(
 
 /**
  * Cancel a running job.
+ *
+ * Distinct from a history delete — this stops the work (best-effort) and
+ * leaves the row in the DB with status=CANCELLED. The history page's
+ * trash button is what wipes the row entirely.
  */
-export async function cancelJob(jobId: string): Promise<void> {
-  const response = await fetch(`/api/matcher/jobs/${jobId}`, {
-    method: "DELETE",
+export async function cancelJob(jobId: string): Promise<MatchJob> {
+  const response = await fetch(`/api/matcher/jobs/${jobId}/cancel`, {
+    method: "POST",
   });
 
   if (!response.ok) {
-    throw new Error("Failed to cancel job");
+    const err = await response.json().catch(() => ({ error: "Cancel failed" }));
+    throw new Error(err.error || `Cancel failed (${response.status})`);
   }
+  return response.json();
 }
 
 /**


### PR DESCRIPTION
The running step previously had one button that just navigated away — no way to actually stop a running job. Two distinct actions now:

- Cancel Job (NEW): forwards to workflows-api DELETE which flips its in-memory status to CANCELLED, then sets the Postgres row to CANCELLED (without deleting the row — history delete is a separate operation). The wizard transitions to the results step showing the cancelled status.
- Run in Background: unchanged — navigates away, job continues server-side, user can return via URL or History.

New POST /api/matcher/jobs/[jobId]/cancel route:
- Distinct from the existing DELETE which wipes the row entirely.
- Best-effort forward to workflows-api: a 404 (orphaned job) doesn't block the Postgres flip — the row still needs to release the single-flight guard.
- Refuses to act on already-terminal rows (returns 400).

The lib/matcher client's cancelJob() now hits the new route and returns the updated MatchJob so the wizard can hydrate the results step from the response without an extra round trip.