### PR TITLE
feat(matcher): resume affordances for backgrounded jobs

### DIFF
--- a/apps/web/app/api/matcher/jobs/route.ts
+++ b/apps/web/app/api/matcher/jobs/route.ts
@@ -232,12 +232,17 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const instanceId = searchParams.get("instanceId");
+    // `?status=inflight` returns only PENDING/PROCESSING. Used by the
+    // matcher landing wizard to discover a server-side running job and
+    // offer a resume banner when no `?jobId=` is in the URL.
+    const statusFilter = searchParams.get("status");
 
     // Query jobs from database
     const jobs = await prisma.matchJob.findMany({
       where: {
         userId: session.user.id,
         ...(instanceId ? { instanceId } : {}),
+        ...(statusFilter === "inflight" ? { status: { in: ["PENDING", "PROCESSING"] } } : {}),
       },
       include: {
         instance: {

--- a/apps/web/components/explore/toolbox/matcher/history/history-table.tsx
+++ b/apps/web/components/explore/toolbox/matcher/history/history-table.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Download, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import { Download, Trash2, ChevronDown, ChevronRight, PlayCircle } from "lucide-react";
 import { downloadJobResult } from "@/lib/matcher/client";
 
 interface HistoryJob {
@@ -206,8 +206,22 @@ export function HistoryTable({ jobs }: { jobs: HistoryJob[] }) {
                           Download
                         </Button>
                       )}
-                      {job.status === "PROCESSING" && (
-                        <span className="text-sm text-muted-foreground">{job.progress}%</span>
+                      {(job.status === "PENDING" || job.status === "PROCESSING") && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            router.push(`/explore/toolbox/matcher?jobId=${job.id}`)
+                          }
+                        >
+                          <PlayCircle className="h-3.5 w-3.5 mr-1" />
+                          Resume
+                          {job.status === "PROCESSING" && (
+                            <span className="ml-2 text-xs text-muted-foreground tabular-nums">
+                              {job.progress}%
+                            </span>
+                          )}
+                        </Button>
                       )}
                       <Button
                         variant="ghost"

--- a/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
+++ b/apps/web/components/explore/toolbox/matcher/matcher-wizard.tsx
@@ -76,6 +76,7 @@ export function MatcherWizard() {
     completedJob: null,
   });
   const [inflightError, setInflightError] = useState<string | null>(null);
+  const [inflightJobId, setInflightJobId] = useState<string | null>(null);
   const hydratedJobIdRef = useRef<string | null>(null);
 
   // Hydrate from `?jobId=…` so refreshing or reopening the page snaps the
@@ -128,6 +129,36 @@ export function MatcherWizard() {
       cancelled = true;
     };
   }, [urlJobId, router]);
+
+  // When the user lands at the wizard with NO ?jobId= but they actually
+  // have a server-side job still running (e.g. they hit "Run in Background"
+  // earlier and then re-opened the matcher), surface a banner with a
+  // resume link. Without this they'd have no way to find the job again
+  // short of digging into History.
+  //
+  // The banner is gated on `urlJobId` directly in the JSX, so we only
+  // need to do the discovery fetch when there's no jobId — and we don't
+  // need to clear inflightJobId on entry, since it's only read when
+  // urlJobId is falsy.
+  useEffect(() => {
+    if (urlJobId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/matcher/jobs?status=inflight");
+        if (!res.ok) return;
+        const jobs = (await res.json()) as Array<{ id: string; status: string }>;
+        if (cancelled) return;
+        const inflight = jobs.find((j) => j.status === "PENDING" || j.status === "PROCESSING");
+        if (inflight) setInflightJobId(inflight.id);
+      } catch {
+        /* best-effort discovery — silent if it fails */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [urlJobId]);
 
   const { createJob } = useMatchJob();
 
@@ -354,7 +385,27 @@ export function MatcherWizard() {
   };
 
   return (
-    <Card className="overflow-hidden max-w-3xl mx-auto">
+    <div className="max-w-3xl mx-auto space-y-4">
+      {/* Inflight banner: when the user lands here with no ?jobId= but
+          has a server-side job still running, give them a one-click way
+          back. Only shown on the upload step — once they're already
+          inside the wizard for some other purpose we don't pile on. */}
+      {!urlJobId && inflightJobId && state.kind === "upload" && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm dark:border-blue-900 dark:bg-blue-950">
+          <span className="text-blue-900 dark:text-blue-200">
+            You have a matcher job running. Resume to view progress or cancel it.
+          </span>
+          <button
+            type="button"
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+            onClick={() => router.push(`/explore/toolbox/matcher?jobId=${inflightJobId}`)}
+          >
+            Resume
+          </button>
+        </div>
+      )}
+
+      <Card className="overflow-hidden">
       <div className="flex items-center gap-1 px-6 py-3 bg-muted/30 border-b font-mono text-sm">
         {DISPLAY_STEPS.map((displayStep, index) => {
           // The "running" stage shows the "results" tick as active (we're
@@ -408,6 +459,7 @@ export function MatcherWizard() {
       </div>
 
       <CardContent className="p-6">{renderStep()}</CardContent>
-    </Card>
+      </Card>
+    </div>
   );
 }


### PR DESCRIPTION
After "Run in Background" navigates the user away, they previously had no surfaced way to find the running job again. Two entry points now:

- History table: PENDING/PROCESSING rows get a Resume button (with the current % alongside) that links to /explore/toolbox/matcher?jobId=... Click → wizard hydrates onto the running step → Cancel Job is right there.

- Matcher landing wizard: when the user opens the matcher with NO ?jobId in the URL but actually has a server-side job still running, show a top banner offering Resume. Discovers the inflight job via GET /api/matcher/jobs?status=inflight (new query param: filter to PENDING/PROCESSING only).

Net result: the loop "submit → run in background → return → cancel" works without requiring the user to remember any URL or jobId.