### PR TITLE
fix(matcher): self-heal missing Excel + server-side single-flight red…

### DIFF
--- a/apps/web/app/[locale]/explore/toolbox/matcher/page.tsx
+++ b/apps/web/app/[locale]/explore/toolbox/matcher/page.tsx
@@ -1,6 +1,9 @@
 import { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { Suspense } from "react";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import { MatcherWizard } from "@/components/explore/toolbox/matcher/matcher-wizard";
 import { Button } from "@/components/ui/button";
 import { Clock, FileSearch } from "lucide-react";
@@ -12,10 +15,36 @@ export const metadata: Metadata = {
 
 interface PageProps {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ jobId?: string }>;
 }
 
-export default async function MatcherPage({ params }: PageProps) {
+export default async function MatcherPage({ params, searchParams }: PageProps) {
   const { locale } = await params;
+  const sp = await searchParams;
+
+  // Server-side single-flight gate: if the user already has a
+  // PENDING/PROCESSING job and isn't already viewing it via ?jobId=,
+  // 302 to the running view. This makes "you can't start a new task
+  // while one is running" a hard server-enforced rule (matches the
+  // partial unique index + API-level 409 check). Eliminates the
+  // upload-step flash from the client-side redirect, and prevents the
+  // user from ever filling out a config that the backend will reject.
+  if (!sp?.jobId) {
+    const session = await auth();
+    if (session?.user?.id) {
+      const inflight = await prisma.matchJob.findFirst({
+        where: {
+          userId: session.user.id,
+          status: { in: ["PENDING", "PROCESSING"] },
+        },
+        select: { id: true },
+        orderBy: { createdAt: "desc" },
+      });
+      if (inflight) {
+        redirect(`/${locale}/explore/toolbox/matcher?jobId=${inflight.id}`);
+      }
+    }
+  }
 
   return (
     <div className="flex flex-col">

--- a/apps/web/app/api/matcher/jobs/[jobId]/download/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/download/route.ts
@@ -6,10 +6,46 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { createReadStream } from "fs";
+import { mkdir, writeFile } from "fs/promises";
 import path from "path";
+import { prisma } from "@/lib/prisma";
 import { requireOwnedJob } from "@/lib/matcher/auth";
 
 const DATA_DIR = path.join(process.cwd(), "data");
+// Server-side only: prefer WORKFLOWS_API_URL, fall back to the public
+// form for backwards-compat. See app/api/matcher/jobs/route.ts.
+const WORKFLOWS_API_URL =
+  process.env.WORKFLOWS_API_URL ||
+  process.env.NEXT_PUBLIC_WORKFLOWS_API_URL ||
+  "http://localhost:2027";
+
+/**
+ * If the row is COMPLETED but `resultFileKey` is null, pull the bytes
+ * from workflows-api and persist them. Self-heals the case where the
+ * status callback flipped the row to COMPLETED before any GET sync
+ * ran, so the wizard's first download attempt would 404 forever.
+ *
+ * Returns the resolved fileKey or null if recovery wasn't possible
+ * (workflows-api lost the bytes; nothing left to fetch).
+ */
+async function ensureResultFile(jobId: string): Promise<string | null> {
+  try {
+    const dlRes = await fetch(
+      `${WORKFLOWS_API_URL}/v1/workflows/matcher/jobs/${jobId}/download?consume=true`,
+    );
+    if (!dlRes.ok) return null;
+    const buffer = Buffer.from(await dlRes.arrayBuffer());
+    const fileKey = `match-results/${jobId}.xlsx`;
+    const filePath = path.join(DATA_DIR, fileKey);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, buffer);
+    await prisma.matchJob.update({ where: { id: jobId }, data: { resultFileKey: fileKey } });
+    return fileKey;
+  } catch (err) {
+    console.error("[Matcher Download] ensureResultFile failed:", err);
+    return null;
+  }
+}
 
 export async function GET(
   _request: NextRequest,
@@ -31,9 +67,22 @@ export async function GET(
       return NextResponse.json({ error: "Job is not completed yet" }, { status: 400 });
     }
 
-    // Check result file exists
-    if (!job.resultFileKey) {
-      return NextResponse.json({ error: "Result file not available yet" }, { status: 404 });
+    // Self-heal: row is COMPLETED but file isn't on disk yet. The
+    // status-callback path can win the race and write COMPLETED to
+    // Postgres before any GET sync had a chance to fetch the Excel.
+    // Pull it now; only return 404 if workflows-api also can't help.
+    let resultFileKey = job.resultFileKey;
+    if (!resultFileKey) {
+      resultFileKey = await ensureResultFile(jobId);
+      if (!resultFileKey) {
+        return NextResponse.json(
+          {
+            error:
+              "Result file is missing and the matcher service no longer has the bytes. Please re-run the job.",
+          },
+          { status: 404 },
+        );
+      }
     }
 
     // Defence in depth: resultFileKey is set by our own code today, but the
@@ -41,13 +90,13 @@ export async function GET(
     // inside DATA_DIR so a poisoned key (`..\..\etc\passwd`) can't read
     // arbitrary files off the host.
     const resolvedDataDir = path.resolve(DATA_DIR);
-    const resolved = path.resolve(resolvedDataDir, job.resultFileKey);
+    const resolved = path.resolve(resolvedDataDir, resultFileKey);
     if (
       resolved !== resolvedDataDir &&
       !resolved.startsWith(resolvedDataDir + path.sep)
     ) {
       console.error(
-        `[Matcher] Rejected out-of-DATA_DIR resultFileKey for job ${jobId}: ${job.resultFileKey}`,
+        `[Matcher] Rejected out-of-DATA_DIR resultFileKey for job ${jobId}: ${resultFileKey}`,
       );
       return new Response("invalid path", { status: 400 });
     }

--- a/apps/web/app/api/matcher/jobs/[jobId]/route.ts
+++ b/apps/web/app/api/matcher/jobs/[jobId]/route.ts
@@ -37,6 +37,52 @@ async function reloadJobWithInstance(jobId: string) {
   });
 }
 
+/**
+ * Pull the Excel bytes from workflows-api, persist to disk, and write
+ * `resultFileKey` on the row. Idempotent: if the row already has a key
+ * (or workflows-api 404s the bytes), returns without doing anything.
+ *
+ * Necessary because the Python → Next.js status callback flips the row
+ * to COMPLETED *before* anyone has fetched the bytes. The wizard's GET
+ * sync used to gate Excel-fetching on `status IN PENDING/PROCESSING`,
+ * so a row that arrived at COMPLETED via the callback path stayed
+ * forever with `resultFileKey: null` and the user got a 404 when they
+ * clicked Download. This helper runs unconditionally on read whenever
+ * (status=COMPLETED && !resultFileKey).
+ */
+async function ensureResultFile(
+  jobId: string,
+  current: { status: string; resultFileKey: string | null },
+): Promise<void> {
+  if (current.status !== "COMPLETED" || current.resultFileKey) return;
+  try {
+    const dlRes = await fetch(
+      `${WORKFLOWS_API_URL}/v1/workflows/matcher/jobs/${jobId}/download?consume=true`,
+    );
+    if (!dlRes.ok) {
+      // workflows-api may have lost the bytes (restart wiped its
+      // in-memory store). Nothing recoverable; row stays without a
+      // resultFileKey and the download endpoint surfaces the 404.
+      return;
+    }
+    const buffer = Buffer.from(await dlRes.arrayBuffer());
+    const fileKey = `match-results/${jobId}.xlsx`;
+    const filePath = path.join(DATA_DIR, fileKey);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, buffer);
+    // Don't filter on status here — the row IS terminal-COMPLETED,
+    // and we only get past the guard at the top of this function if
+    // resultFileKey is null. Idempotent against concurrent runs:
+    // both write the same fileKey.
+    await prisma.matchJob.update({
+      where: { id: jobId },
+      data: { resultFileKey: fileKey },
+    });
+  } catch (err) {
+    console.error("[Matcher Jobs] ensureResultFile failed:", err);
+  }
+}
+
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ jobId: string }> },
@@ -67,6 +113,16 @@ export async function GET(
 
     if (!job) {
       return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+
+    // Cover the "callback wrote COMPLETED before any sync ran" case:
+    // if the row is already terminal-COMPLETED on entry but the Excel
+    // hasn't been persisted, fetch it now. After this the rest of the
+    // sync logic only runs for non-terminal rows.
+    if (job.status === "COMPLETED" && !job.resultFileKey) {
+      await ensureResultFile(jobId, { status: job.status, resultFileKey: job.resultFileKey });
+      const fresh = await reloadJobWithInstance(jobId);
+      return NextResponse.json(fresh ?? job);
     }
 
     // If job is not in a terminal state, sync progress from matcher service.


### PR DESCRIPTION
…irect

Two follow-up issues from review:

1. Download fails with "Result file not available yet" when the status-callback path wins the race against the GET sync. Python's update_job posts COMPLETED to Postgres directly; if the user clicks Download before any GET sync poll has fetched the Excel bytes, the row stays at COMPLETED with resultFileKey=null and the download endpoint 404s forever.

   Fix: extract `ensureResultFile(jobId)` helper that pulls the bytes from workflows-api with ?consume=true, persists to disk, and sets resultFileKey on the row. Idempotent. Called from two places:

   - GET /jobs/[id]: when the row arrives terminal-COMPLETED on entry with no resultFileKey, run the helper before responding so the wizard / history sees a complete row on first load.
   - GET /jobs/[id]/download: as defense-in-depth — if anything still reaches the download route without a resultFileKey, try to recover before returning 404. The 404 message now also tells the user the matcher service has lost the bytes, not a vague "not available yet" that read like "wait longer".

2. Stricter single-flight: the matcher landing page now redirects server-side when the user has a PENDING/PROCESSING job and no ?jobId= in the URL. Layered with the partial unique index and the API-level 409, this makes "you can't start a new task while one is running" a hard server-enforced rule. Eliminates the upload-step flash that the previous client-side redirect produced, and prevents the user from ever filling out a config that the backend will reject.