### PR TITLE
fix(matcher migration): self-clean duplicate inflight rows before uni…

### DIFF
--- a/apps/web/prisma/migrations/20260504000000_matchjob_one_inflight_per_user/migration.sql
+++ b/apps/web/prisma/migrations/20260504000000_matchjob_one_inflight_per_user/migration.sql
@@ -3,12 +3,36 @@
 -- can't (two tabs both passing the read, both spawning LOTUS jobs,
 -- both burning BYOK tokens). Prisma's @@unique can't represent a
 -- partial index, so this lives as raw SQL.
+
+-- Step 1: pre-clean any duplicates that violate the new constraint.
+-- The application-level findFirst+create gate was racy, so it's
+-- possible for a single user to have multiple PENDING/PROCESSING
+-- rows in the DB at deploy time. Without this cleanup the
+-- CREATE UNIQUE INDEX below fails with 23505 and the entire
+-- migration aborts (P3018), blocking all subsequent deploys.
 --
--- Existing rows in PENDING/PROCESSING per user are tolerated (the
--- unique constraint is built CONCURRENTLY-friendly here for safety in
--- prod — small tables get a near-instant index, large ones avoid
--- locking writers). If two rows already exist for one user, this
--- migration fails fast and a manual cleanup is required first.
+-- Heuristic: keep the most recent inflight row per user, FAIL the
+-- rest. The most recent is the one the user is likely watching; the
+-- older ones are abandoned by the new wizard's force-redirect to
+-- the latest job anyway. Idempotent — the WHERE clause matches
+-- nothing on a fresh DB.
+UPDATE "match_jobs" AS m1
+SET
+  "status" = 'FAILED',
+  "errorMessage" = 'Migration cleanup: only one inflight matcher job per user is allowed.',
+  "completedAt" = NOW(),
+  "updatedAt" = NOW()
+WHERE
+  m1."status" IN ('PENDING', 'PROCESSING')
+  AND EXISTS (
+    SELECT 1 FROM "match_jobs" AS m2
+    WHERE m2."userId" = m1."userId"
+      AND m2."status" IN ('PENDING', 'PROCESSING')
+      AND (m2."createdAt" > m1."createdAt"
+           OR (m2."createdAt" = m1."createdAt" AND m2."id" > m1."id"))
+  );
+
+-- Step 2: now safe to create the partial unique index.
 CREATE UNIQUE INDEX "match_jobs_user_inflight_unique"
 ON "match_jobs" ("userId")
 WHERE "status" IN ('PENDING', 'PROCESSING');


### PR DESCRIPTION
…que index

P3018 on prod deploy: user cmolkh0v4000301oe50z6nuro already had multiple PENDING/PROCESSING match_jobs rows when the partial unique index migration ran, so CREATE UNIQUE INDEX raised 23505 and aborted the migration mid-flight, blocking all subsequent deploys.

The application-level findFirst+create gate was racy (that's exactly what the new index is meant to fix), so any DB existing before this deploy can have duplicate inflights. The migration must clean them up before creating the constraint.

Heuristic: keep the most recent inflight row per user, FAIL the rest with a clear errorMessage. The most recent is what the wizard now force-redirects to anyway; older rows are abandoned. Idempotent — the UPDATE matches nothing on a fresh DB.

Operator recovery on the failed deployment:

  # 1. Mark the failed migration rolled-back so deploy can retry it
  docker compose -f docker-compose.server.yml exec migrate \
    npx prisma migrate resolve --rolled-back 20260504000000_matchjob_one_inflight_per_user

  # 2. Re-deploy with this commit
  git pull
  docker compose -f docker-compose.server.yml --profile prod up -d --build

The cleanup UPDATE will run, the index will create, and the migrate container will exit 0.