### PR TITLE
refactor(digest-worker): forward to workflows-api over HTTP

### DIFF
--- a/apps/langgraph/server/app.py
+++ b/apps/langgraph/server/app.py
@@ -6,6 +6,7 @@ routes are stateless; each request carries its own config + model settings.
 
 from __future__ import annotations
 
+import os
 from contextlib import asynccontextmanager
 from dataclasses import asdict
 from pathlib import Path
@@ -26,7 +27,7 @@ load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 from arq import create_pool  # noqa: E402
 from arq.connections import ArqRedis  # noqa: E402
 from fastapi import FastAPI, HTTPException, Request  # noqa: E402
-from workflows.daily_digest import GenerateSectionRequest  # noqa: E402
+from workflows.daily_digest import GenerateSectionRequest, generate_section  # noqa: E402
 from workflows.digest_worker import WorkerSettings  # noqa: E402
 from workflows.search import SearchRequest, search  # noqa: E402
 
@@ -63,6 +64,33 @@ async def healthz() -> dict[str, bool]:
 async def search_route(req: SearchRequest) -> dict[str, Any]:
     result = await search(req)
     return {"items": result.items, "reasons": result.reasons}
+
+
+def _require_internal_token(request: Request) -> None:
+    """Guard internal-only routes. The token must be configured (no silent
+    bypass on missing config) so dev mistakes fail loud rather than leaving
+    an expensive endpoint open."""
+    expected = os.getenv("INTERNAL_CALLBACK_TOKEN", "")
+    if not expected:
+        raise HTTPException(status_code=500, detail="INTERNAL_CALLBACK_TOKEN not configured")
+    if request.headers.get("X-Internal-Token", "") != expected:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+@app.post("/v1/workflows/daily_digest/sections/{section_id}/run")
+async def daily_digest_run(
+    section_id: str,
+    req: GenerateSectionRequest,
+    request: Request,
+):
+    """Execute a digest section synchronously. Internal-only — invoked by
+    the digest-worker after it picks up its arq job. Lets the worker stay
+    a thin arq+httpx shim with no langgraph/langchain runtime."""
+    _require_internal_token(request)
+    if req.section_id != section_id:
+        raise HTTPException(status_code=400, detail="section_id mismatch")
+    result = await generate_section.ainvoke(req)
+    return {"ok": True, "result": result}
 
 
 @app.post("/v1/workflows/daily_digest/sections/{section_id}/generate", status_code=202)

--- a/apps/langgraph/workflows/digest_tasks.py
+++ b/apps/langgraph/workflows/digest_tasks.py
@@ -1,13 +1,46 @@
-"""ARQ task adapter for daily-digest generation."""
+"""ARQ task adapter for daily-digest generation.
+
+Forwards the picked-up job to workflows-api over HTTP rather than importing
+``daily_digest`` directly. This keeps the digest-worker container a thin
+arq+httpx shim with no langgraph/langchain runtime — those live behind the
+workflows-api process. See ``apps/langgraph/Dockerfile.worker``.
+"""
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
-from workflows.daily_digest import GenerateSectionRequest, generate_section
+import httpx
+
+# WORKFLOWS_API_URL points at the workflows-api this worker should call.
+# In dev compose: http://host.docker.internal:2027 (workflows-api runs on
+# host). In prod compose with profile=prod: http://workflows-api:2027.
+WORKFLOWS_API_URL = os.getenv("WORKFLOWS_API_URL", "http://localhost:2027")
+
+# Generous timeout: a section's LOTUS rank + LLM calls can take several
+# minutes for large pools. Aligned with the arq max_tries budget — one
+# failed attempt should be a real failure, not a timeout race.
+_RUN_TIMEOUT_S = float(os.getenv("DIGEST_RUN_TIMEOUT", "600"))
 
 
 async def arq_generate_section(ctx: dict, payload: dict[str, Any]) -> Any:
     _ = ctx  # ARQ protocol; unused here.
-    req = GenerateSectionRequest(**payload)
-    return await generate_section.ainvoke(req)
+    section_id = payload.get("section_id")
+    if not section_id:
+        raise ValueError("payload missing section_id")
+
+    # INTERNAL_CALLBACK_TOKEN must match the workflows-api side. No fallback:
+    # a missing token here means the request will be rejected with 500 on
+    # the receiving end, which is the desired loud failure.
+    token = os.getenv("INTERNAL_CALLBACK_TOKEN", "")
+    headers = {"X-Internal-Token": token} if token else {}
+
+    async with httpx.AsyncClient(timeout=_RUN_TIMEOUT_S) as client:
+        resp = await client.post(
+            f"{WORKFLOWS_API_URL}/v1/workflows/daily_digest/sections/{section_id}/run",
+            json=payload,
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -135,6 +135,12 @@ services:
     container_name: sparkflow-digest-worker
     command: ["arq", "workflows.digest_worker.WorkerSettings"]
     env_file: ./.env
+    # The worker forwards arq jobs to the workflows-api over HTTP — see
+    # apps/langgraph/workflows/digest_tasks.py. Pin the URL inline so it
+    # doesn't depend on .env being current; on this network the API is
+    # always reachable as http://workflows-api:2027.
+    environment:
+      WORKFLOWS_API_URL: http://workflows-api:2027
     volumes:
       - ./ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
     depends_on:
@@ -142,6 +148,8 @@ services:
         condition: service_healthy
       semops:
         condition: service_healthy
+      workflows-api:
+        condition: service_started
     restart: unless-stopped
 
   # ── Production-only services (opt-in via --profile prod) ──────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,11 +120,14 @@ services:
     env_file:
       - ./apps/web/.env             # shared: INTERNAL_CALLBACK_TOKEN, SPARKFLOW_API_URL
       - ./apps/langgraph/.env       # langgraph-only: DIGEST_WORKER_CONCURRENCY, LANGSMITH_*
-    # Local-dev override: in-docker hostname for redis + semops.
+    # Local-dev override: in-docker hostname for redis + semops, host.docker.internal
+    # for the workflows-api (which the worker forwards arq jobs to over HTTP — see
+    # apps/langgraph/workflows/digest_tasks.py).
     environment:
       REDIS_URL: redis://redis:6379
       SEMOPS_API_URL: http://semops:2025
-      SPARKFLOW_API_URL: http://host.docker.internal:3001  # web runs on host in dev mode
+      SPARKFLOW_API_URL: http://host.docker.internal:3001    # web runs on host in dev mode
+      WORKFLOWS_API_URL: http://host.docker.internal:2027    # workflows-api runs on host in dev mode
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- The digest-worker container is supposed to be a thin **arq + httpx** shim per its `Dockerfile.worker` comment, but `digest_tasks.py` had drifted to import `daily_digest` directly, which imports `langgraph.func` at module load. Every fresh image build crash-loops with `ModuleNotFoundError: No module named 'langgraph'`.
- This realigns runtime with the original design: the langgraph workflow runs inside `workflows-api` (which already has the deps); the worker forwards over HTTP and goes back to needing only arq+httpx.

## Changes
- **`apps/langgraph/server/app.py`** — new internal-only `POST /v1/workflows/daily_digest/sections/{section_id}/run` that calls `generate_section.ainvoke(req)`. Guarded by `X-Internal-Token` (the token already used by the apps/web callback). Token **must** be configured — missing config returns 500 rather than silently leaving the endpoint open.
- **`apps/langgraph/workflows/digest_tasks.py`** — rewritten as an httpx forwarder. No more langgraph import; just POSTs the payload to the new `/run` route with a 600s timeout (sized for full LOTUS rank + LLM calls).
- **`docker-compose.yml`** + **`docker-compose.server.yml`** — `WORKFLOWS_API_URL` inline-overridden on `digest-worker` so the URL doesn't depend on `.env` drift. Dev → `host.docker.internal:2027` (workflows-api on host). Server (`--profile prod`) → `http://workflows-api:2027` (in-network), plus a `depends_on` edge so the API is up before the worker accepts jobs.

## Test plan
- [x] `docker compose build digest-worker && docker compose up -d --no-deps --no-build digest-worker` — container starts clean (`Starting worker for 1 functions: arq_generate_section`), no `ModuleNotFoundError`.
- [x] `curl -X POST .../run` smoke-tests:
  - no `X-Internal-Token` → 401
  - wrong token → 401
  - matching token, mismatched `section_id` → 400
- [ ] End-to-end: enqueue a digest section via `POST /v1/workflows/daily_digest/sections/{id}/generate`, verify the worker picks it up, the `/run` route fires `generate_section`, and the existing callback chain still hits apps/web.