### PR TITLE
fix(web docker): npm cache mount + maxsockets cap + arch-aware SWC

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,11 +21,14 @@ ENV DATABASE_URL=postgresql://placeholder:placeholder@localhost:5432/placeholder
 
 # Corp networks frequently kill long npm fetches with ECONNRESET. Bump
 # retry count + timeouts so transient drops auto-recover instead of
-# failing the whole `docker compose build`.
+# failing the whole `docker compose build`. Also cap concurrent
+# connections — corp proxies sometimes reset-bomb when too many
+# parallel package fetches hit them at once.
 ENV NPM_CONFIG_FETCH_RETRIES=5
 ENV NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000
 ENV NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000
 ENV NPM_CONFIG_FETCH_TIMEOUT=600000
+ENV NPM_CONFIG_MAXSOCKETS=3
 
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
@@ -37,15 +40,26 @@ COPY prisma.config.ts ./
 # NODE_EXTRA_CA_CERTS set. Disable verification just for this one fetch;
 # all subsequent stages run with normal cert validation.
 #
-# `npm install --no-save @next/swc-linux-x64-gnu` is a workaround for
+# `npm install --no-save @next/swc-linux-${arch}-gnu` is a workaround for
 # corp-network builds: if the lockfile was generated on macOS the linux
 # SWC binary isn't pinned, and `next build` falls back to fetching it
 # directly from Cloudflare (104.16.x.x), which most corp firewalls block.
 # Pulling it explicitly via the configured npm registry (the same one
 # `npm ci` just used) guarantees the binary is in node_modules before
 # `next build` looks for it. `--no-save` keeps package.json clean.
-RUN npm ci && \
-    npm install --no-save --no-audit @next/swc-linux-x64-gnu && \
+# Arch-aware: TARGETARCH is provided by buildx, so arm64 hosts get the
+# right SWC instead of amd64-only.
+#
+# `--mount=type=cache,target=/root/.npm` persists npm's package cache
+# across builds (mirrors what semops/workflows-api do for uv). On a
+# flaky corp network the first build still has to pull packages, but
+# any subsequent build/retry reuses what's cached locally — turns a
+# 200-package fetch into a near-noop.
+ARG TARGETARCH
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci && \
+    if [ "$TARGETARCH" = "arm64" ]; then SWC=arm64; else SWC=x64; fi && \
+    npm install --no-save --no-audit "@next/swc-linux-${SWC}-gnu" && \
     NODE_TLS_REJECT_UNAUTHORIZED=0 npx prisma generate
 
 COPY . .

--- a/apps/web/Dockerfile.worker
+++ b/apps/web/Dockerfile.worker
@@ -22,11 +22,14 @@ FROM base AS deps
 
 # Corp networks frequently kill long npm fetches with ECONNRESET. Bump
 # retry count + timeouts so transient drops auto-recover instead of
-# failing the whole build.
+# failing the whole build. Also cap concurrent connections — corp
+# proxies sometimes reset-bomb when too many parallel package fetches
+# hit them at once.
 ENV NPM_CONFIG_FETCH_RETRIES=5
 ENV NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000
 ENV NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000
 ENV NPM_CONFIG_FETCH_TIMEOUT=600000
+ENV NPM_CONFIG_MAXSOCKETS=3
 
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
@@ -34,7 +37,16 @@ COPY prisma ./prisma
 # downloads its engine binaries from binaries.prisma.sh, which on TLS-
 # intercepting corporate networks fails the cert chain even with
 # NODE_EXTRA_CA_CERTS set. Disable verification just for this one fetch.
-RUN npm ci && NODE_TLS_REJECT_UNAUTHORIZED=0 npx prisma generate
+#
+# `--mount=type=cache,target=/root/.npm` persists npm's package cache
+# across builds (mirrors what semops/workflows-api do for uv). On a
+# flaky corp network the first build still has to pull packages, but
+# any subsequent build/retry reuses what's cached locally — turns a
+# 200-package fetch into a near-noop. Shared with apps/web/Dockerfile
+# since both build npm packages from the same lockfile.
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci && \
+    NODE_TLS_REJECT_UNAUTHORIZED=0 npx prisma generate
 
 FROM base AS runtime
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
The ingest-worker build kept dying mid-`npm ci` with ECONNRESET on the corp-network deploy even with NPM_CONFIG_FETCH_RETRIES=5 — each retry re-pulls the entire 200+ package set over the same flaky proxy, and the proxy reset-bombs when too many parallel fetches hit it.

Three changes, mirroring what semops / workflows-api already do for their uv installs:

1. `--mount=type=cache,target=/root/.npm` on the npm-ci RUN steps in both Dockerfile and Dockerfile.worker. Persists npm's package cache across builds and across the two images (same lockfile). The first build still pulls everything, but subsequent builds/retries hit the local cache instead of the corp proxy — turns a 3-minute network-bound install into a near-noop.

2. NPM_CONFIG_MAXSOCKETS=3 caps concurrent connections. Default is 50; the corp proxy resets long-tail connections when it sees that many in-flight at once. 3 is conservative but works.

3. Brought in main's arch-aware SWC pre-install (`ARG TARGETARCH; if arm64 then SWC=arm64 else SWC=x64`) so arm64 hosts (apple silicon dev machines) don't end up trying to load the amd64 SWC binary.

Operator action on the failed deploy:
  git pull
  docker compose -f docker-compose.server.yml --profile prod up -d --build

The first build will pull everything (still slow on the corp net but should now actually finish thanks to maxsockets=3). Subsequent builds will be near-instant on the npm-ci layer.