### PR TITLE
fix(compose): pin digest-worker to prod profile to match workflows-api

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -127,6 +127,13 @@ services:
     restart: unless-stopped
 
   digest-worker:
+    # Pinned to the `prod` profile because this worker forwards every
+    # arq job to workflows-api over HTTP, and workflows-api is itself
+    # prod-only. Without this, default-profile compose commands fail
+    # with `service "digest-worker" depends on undefined service
+    # "workflows-api"` — compose can't resolve the dep when only one
+    # of the pair is in scope.
+    profiles: ["prod"]
     build:
       context: ./apps/langgraph
       dockerfile: Dockerfile.worker


### PR DESCRIPTION
After PR #187 wired digest-worker to forward arq jobs to workflows-api over HTTP, digest-worker grew a depends_on: workflows-api. But workflows-api is profiles: ["prod"], and digest-worker had no profile — so default-profile compose commands fail validation with "service \"digest-worker\" depends on undefined service \"workflows-api\": invalid compose project" before they can do anything.

That blocks every `docker compose run --rm migrate ...` (and any other no-profile compose invocation) on prod hosts. Specifically blocked the recovery command for the failed P3009 migration.

Fix: pin digest-worker to the same prod profile. They're a unit — the worker can't function without the API, and both are prod-only by design (in dev, host runs `make serve` + `arq` directly).