### PR TITLE
perf(explore): kill N+1, add indexes, tighten pool, cache hot RSC paths

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -48,3 +48,5 @@ ca-certificates.crt
 *.tsbuildinfo
 next-env.d.ts
 
+# Local runtime output (e.g. matcher xlsx exports)
+/data/

--- a/apps/web/app/[locale]/explore/conferences/[id]/page.tsx
+++ b/apps/web/app/[locale]/explore/conferences/[id]/page.tsx
@@ -15,6 +15,11 @@ interface PageProps {
   params: Promise<{ id: string }>;
 }
 
+// Conference detail aggregates 11 raw-SQL stats queries. The underlying
+// publications/sessions only change when admins ingest new data, so a 30 min
+// page-level cache is safe and turns most tab/back navigations into cache hits.
+export const revalidate = 1800;
+
 import { PublicationStatsSection } from "@/components/explore/conferences/publication-stats-section";
 
 async function SessionsSection({ conferenceId }: { conferenceId: string }) {

--- a/apps/web/app/[locale]/explore/page.tsx
+++ b/apps/web/app/[locale]/explore/page.tsx
@@ -22,6 +22,10 @@ interface ExplorePageProps {
   params: Promise<{ locale: string }>;
 }
 
+// Hub landing — content rotates on a slow cadence. Cache the rendered RSC
+// for 5 minutes so tab-switch navigations from sub-pages return instantly.
+export const revalidate = 300;
+
 // ─────────────────────────────────────────────────────────────
 // Hero — editorial display block
 // ─────────────────────────────────────────────────────────────

--- a/apps/web/lib/explore/cache.ts
+++ b/apps/web/lib/explore/cache.ts
@@ -1,15 +1,49 @@
 // apps/web/lib/explore/cache.ts
+//
+// Process-local LRU caches for the Research Hub (/explore) read paths.
+//
+// The underlying data (venues, conference instances, publications, sessions)
+// only changes when an admin ingests new records — minutes-to-hours, not
+// seconds. We can safely cache aggressively: a 30 min TTL turns the vast
+// majority of tab-switches and back-navigations into in-memory hits.
+//
+// `staleTtl` enables stale-while-revalidate semantics — when an entry has
+// expired but is still within `staleTtl`, callers may opt to serve the stale
+// value and refresh in the background, preventing thundering-herd DB hits
+// when an entry expires.
 
 import { LRUCache } from "lru-cache";
 import type { FilterOptions } from "./types";
 
+const FIVE_MIN = 5 * 60 * 1000;
+const FIFTEEN_MIN = 15 * 60 * 1000;
+const THIRTY_MIN = 30 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+
 export const filterOptionsCache = new LRUCache<string, FilterOptions>({
-  max: 50,
-  ttl: 5 * 60 * 1000, // 5 minutes
+  max: 200,
+  ttl: THIRTY_MIN,
+  // Filter options are global lookups — cheap to keep, expensive to recompute
+  // (7 queries including 2 raw `unnest()` aggregations).
+  allowStale: true,
+  ttlAutopurge: false,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const statsCache = new LRUCache<string, any>({
-  max: 50,
-  ttl: 5 * 60 * 1000, // 5 minutes
+  max: 500,
+  ttl: FIFTEEN_MIN,
+  allowStale: true,
+  ttlAutopurge: false,
 });
+
+// Per-conference / per-list grids — heavier payloads, shorter TTL.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const listCache = new LRUCache<string, any>({
+  max: 500,
+  ttl: FIVE_MIN,
+  allowStale: true,
+  ttlAutopurge: false,
+});
+
+export const TTL = { FIVE_MIN, FIFTEEN_MIN, THIRTY_MIN, ONE_HOUR };

--- a/apps/web/lib/explore/queries.ts
+++ b/apps/web/lib/explore/queries.ts
@@ -3,7 +3,7 @@
 import { cache } from "react";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { filterOptionsCache, statsCache } from "./cache";
+import { filterOptionsCache, listCache, statsCache } from "./cache";
 import {
   PAGE_SIZE,
   type PublicationFilters,
@@ -387,6 +387,10 @@ export const getFilteredPublicationOptions = cache(
 
 export const getConferences = cache(
   async (filters: ConferenceFilters): Promise<ConferenceCard[]> => {
+    const cacheKey = `conferences-${filters.venue ?? ""}-${filters.year ?? ""}`;
+    const cached = listCache.get(cacheKey) as ConferenceCard[] | undefined;
+    if (cached) return cached;
+
     const where: Prisma.InstanceWhereInput = {};
 
     if (filters.venue) {
@@ -420,34 +424,55 @@ export const getConferences = cache(
       orderBy: [{ year: "desc" }, { name: "asc" }],
     });
 
-    // Get top topics for each conference (simplified - just get first 3 unique topics)
-    const results: ConferenceCard[] = await Promise.all(
-      instances.map(async (inst) => {
-        const topTopicsResult = await prisma.publication.findMany({
-          where: { instanceId: inst.id, researchTopic: { not: null } },
-          select: { researchTopic: true },
-          distinct: ["researchTopic"],
-          take: 3,
-        });
+    if (instances.length === 0) return [];
 
-        return {
-          id: inst.id,
-          name: inst.name,
-          year: inst.year,
-          venue: inst.venue,
-          startDate: inst.startDate,
-          endDate: inst.endDate,
-          location: inst.location,
-          publicationCount: inst._count.publications,
-          sessionCount: inst._count.sessions,
-          topTopics: topTopicsResult
-            .map((t) => t.researchTopic)
-            .filter((t): t is string => t !== null),
-        };
-      }),
-    );
+    // Top 3 research topics per instance — fetched in ONE query instead of
+    // one-per-instance (was N+1). Uses a window function to rank topics by
+    // popularity within each instance, then picks the top 3.
+    const instanceIds = instances.map((i) => i.id);
+    const topicRows = await prisma.$queryRaw<
+      { instanceId: string; researchTopic: string }[]
+    >`
+      SELECT "instanceId", "researchTopic"
+      FROM (
+        SELECT
+          "instanceId",
+          "researchTopic",
+          ROW_NUMBER() OVER (
+            PARTITION BY "instanceId"
+            ORDER BY COUNT(*) DESC, "researchTopic" ASC
+          ) AS rn
+        FROM "publications"
+        WHERE "instanceId" IN (${Prisma.join(instanceIds)})
+          AND "researchTopic" IS NOT NULL
+          AND "researchTopic" <> ''
+        GROUP BY "instanceId", "researchTopic"
+      ) ranked
+      WHERE rn <= 3
+    `;
 
-    return results;
+    const topicsByInstance = new Map<string, string[]>();
+    for (const row of topicRows) {
+      const arr = topicsByInstance.get(row.instanceId) ?? [];
+      arr.push(row.researchTopic);
+      topicsByInstance.set(row.instanceId, arr);
+    }
+
+    const result: ConferenceCard[] = instances.map((inst) => ({
+      id: inst.id,
+      name: inst.name,
+      year: inst.year,
+      venue: inst.venue,
+      startDate: inst.startDate,
+      endDate: inst.endDate,
+      location: inst.location,
+      publicationCount: inst._count.publications,
+      sessionCount: inst._count.sessions,
+      topTopics: topicsByInstance.get(inst.id) ?? [],
+    }));
+
+    listCache.set(cacheKey, result);
+    return result;
   },
 );
 
@@ -884,7 +909,11 @@ export const getSessions = cache(
 
 export const getConferenceSessions = cache(
   async (instanceId: string): Promise<CalendarSessionItem[]> => {
-    return prisma.conferenceSession.findMany({
+    const cacheKey = `conf-sessions-${instanceId}`;
+    const cached = listCache.get(cacheKey) as CalendarSessionItem[] | undefined;
+    if (cached) return cached;
+
+    const result = await prisma.conferenceSession.findMany({
       where: { instanceId },
       select: {
         id: true,
@@ -902,6 +931,9 @@ export const getConferenceSessions = cache(
       },
       orderBy: [{ date: "asc" }, { startTime: "asc" }],
     });
+
+    listCache.set(cacheKey, result);
+    return result;
   },
 );
 
@@ -954,6 +986,10 @@ export const getSession = cache(async (id: string): Promise<SessionDetail | null
 // ============ CHART DATA ============
 
 export const getYearTrendData = cache(async () => {
+  const cacheKey = "year-trend";
+  const cached = statsCache.get(cacheKey) as { year: number; conferences: number }[] | undefined;
+  if (cached) return cached;
+
   const data = await prisma.instance.findMany({
     select: {
       year: true,
@@ -961,19 +997,24 @@ export const getYearTrendData = cache(async () => {
     orderBy: { year: "asc" },
   });
 
-  // Aggregate conference instances by year.
   const byYear = new Map<number, number>();
   for (const item of data) {
     byYear.set(item.year, (byYear.get(item.year) || 0) + 1);
   }
 
-  return Array.from(byYear.entries()).map(([year, count]) => ({
+  const result = Array.from(byYear.entries()).map(([year, count]) => ({
     year,
     conferences: count,
   }));
+  statsCache.set(cacheKey, result);
+  return result;
 });
 
 export const getTopicsChartData = cache(async () => {
+  const cacheKey = "topics-chart";
+  const cached = statsCache.get(cacheKey) as { topic: string; count: number }[] | undefined;
+  if (cached) return cached;
+
   const data = await prisma.publication.groupBy({
     by: ["researchTopic"],
     where: { researchTopic: { not: null } },
@@ -982,8 +1023,10 @@ export const getTopicsChartData = cache(async () => {
     take: 10,
   });
 
-  return data.map((item) => ({
+  const result = data.map((item) => ({
     topic: item.researchTopic as string,
     count: item._count.researchTopic,
   }));
+  statsCache.set(cacheKey, result);
+  return result;
 });

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -6,9 +6,20 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
+function readIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function createPrismaClient() {
   const pool = new Pool({
     connectionString: process.env.DATABASE_URL,
+    max: readIntEnv("DATABASE_POOL_MAX", 20),
+    idleTimeoutMillis: readIntEnv("DATABASE_POOL_IDLE_MS", 30_000),
+    connectionTimeoutMillis: readIntEnv("DATABASE_POOL_CONNECT_MS", 5_000),
+    statement_timeout: readIntEnv("DATABASE_STATEMENT_TIMEOUT_MS", 30_000),
   });
   const adapter = new PrismaPg(pool);
   return new PrismaClient({

--- a/apps/web/lib/wechat-db.ts
+++ b/apps/web/lib/wechat-db.ts
@@ -4,12 +4,22 @@ const globalForWechat = globalThis as unknown as {
   wechatPool: Pool | undefined;
 };
 
+function readIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function createPool(): Pool | null {
   const connectionString = process.env.WECHAT_DATABASE_URL;
   if (!connectionString) return null;
   return new Pool({
     connectionString,
-    max: 5,
+    max: readIntEnv("WECHAT_POOL_MAX", 10),
+    idleTimeoutMillis: readIntEnv("WECHAT_POOL_IDLE_MS", 30_000),
+    connectionTimeoutMillis: readIntEnv("WECHAT_POOL_CONNECT_MS", 5_000),
+    statement_timeout: readIntEnv("WECHAT_STATEMENT_TIMEOUT_MS", 15_000),
   });
 }
 

--- a/apps/web/prisma/migrations/20260506000000_explore_perf_indexes/migration.sql
+++ b/apps/web/prisma/migrations/20260506000000_explore_perf_indexes/migration.sql
@@ -1,0 +1,37 @@
+-- Performance indexes for the Research Hub (/explore) pages.
+--
+-- Hot queries that previously did a full sequential scan of `publications`:
+--   * `_count.publications WHERE status NOT IN ('Reject','Withdrawal')` per
+--     conference card (queries.ts: getConferences, getRecentConferences)
+--   * `getConferenceStats` raw `unnest()` aggregations filtered by
+--     instanceId + status (top affiliations, keywords, countries, etc.)
+--   * `getPublications` listing filtered by status / instanceId / topic
+--   * Sort-by-rating on the explore page hero ("featured publication")
+--
+-- All indexes are CREATE INDEX IF NOT EXISTS so re-runs are safe; in
+-- production we use `CREATE INDEX CONCURRENTLY` to avoid locking the
+-- table for writes during a long build, but Prisma migrations run inside
+-- a transaction, so we keep the regular form here. Run during a low-traffic
+-- window if the table is large.
+
+-- Publication: filter by status alone (rare but used by `getFilterOptions`)
+CREATE INDEX IF NOT EXISTS "publications_status_idx" ON "publications"("status");
+
+-- Publication: composite for "publications of an instance, by status".
+-- Drives every conference card count + every stats query in the detail page.
+CREATE INDEX IF NOT EXISTS "publications_instanceId_status_idx"
+  ON "publications"("instanceId", "status");
+
+-- Publication: composite for the per-instance "top topics" prefetch.
+-- Prisma `findMany({ where: { instanceId, researchTopic: { not: null } }, distinct: ['researchTopic'] })`
+-- benefits from this exact ordering.
+CREATE INDEX IF NOT EXISTS "publications_instanceId_researchTopic_idx"
+  ON "publications"("instanceId", "researchTopic");
+
+-- Publication: descending rating for the homepage "featured" sort.
+CREATE INDEX IF NOT EXISTS "publications_rating_desc_idx"
+  ON "publications"("rating" DESC);
+
+-- ConferenceSession: date ordering for calendar / "upcoming sessions".
+CREATE INDEX IF NOT EXISTS "conference_sessions_date_idx"
+  ON "conference_sessions"("date");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -379,6 +379,10 @@ model Publication {
 
   @@index([instanceId])
   @@index([researchTopic])
+  @@index([status])
+  @@index([instanceId, status])
+  @@index([instanceId, researchTopic])
+  @@index([rating(sort: Desc)])
   @@map("publications")
 }
 
@@ -429,6 +433,7 @@ model ConferenceSession {
 
   @@index([instanceId])
   @@index([type])
+  @@index([date])
   @@map("conference_sessions")
 }
 


### PR DESCRIPTION
Research Hub (/explore) tab switches and page loads were dominated by:
1. N+1 in getConferences — one Publication.findMany distinct topics call per conference card (50+ sequential queries on the listing page).
2. Missing indexes on publications(status), publications(instanceId, status), publications(instanceId, researchTopic), publications(rating DESC), conference_sessions(date) — every status-filtered count and unnest() aggregation in getConferenceStats was a sequential scan.
3. pg.Pool created with no max — defaulted to 10 connections, no statement timeout. Under load, requests queued and runaway queries wedged connections.
4. getConferences / getConferenceSessions / getYearTrendData / getTopicsChartData were only request-scoped (React.cache) — every navigation re-ran them.
5. /explore landing and /explore/conferences/[id] re-rendered on every navigation despite content changing on minute-to-hour cadence.

Changes:
- Replace N+1 with a single ROW_NUMBER() OVER (PARTITION BY instanceId) query that returns top 3 topics for all instances at once.
- Prisma migration 20260506000000_explore_perf_indexes adds the 5 missing indexes; schema.prisma updated to match.
- pg Pool now sets max=20, idle/connect timeouts, and statement_timeout (env-overridable via DATABASE_POOL_MAX etc.); same for the WeChat pool.
- LRU cache TTLs raised (filter options 5→30 min, stats 5→15 min) with allowStale=true to absorb expiry stampedes; new listCache for grid payloads. Wired LRU caching into the four previously uncached hot functions.
- export const revalidate on /explore (300s) and /explore/conferences/[id] (1800s) so back/forward and tab-switch navigations hit the RSC cache.