### PR TITLE
fix(wechat): serve images from internal DB before touching external

### DIFF
--- a/apps/web/app/api/wechat/proxy-image/route.ts
+++ b/apps/web/app/api/wechat/proxy-image/route.ts
@@ -1,16 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
+import { wechatPool } from "@/lib/wechat-db";
 
-// WeChat cover images are stored in our DB pointing at a third-party relay
-// (img2.jintiankansha.me/get?src=<mmbiz_url>). The relay is unreliable and
-// has been returning 502 for whole batches of images. The underlying source
-// is Tencent's mmbiz.qpic.cn CDN, which is far more stable but requires a
-// `Referer: https://mp.weixin.qq.com/` header to serve cross-origin.
+// WeChat article images are mirrored into `wechat_articles.images.data` on
+// ingest, with the source URL stored in `images.original_url`. The covers
+// (and most inline images) the browser asks for via this proxy are already
+// present in our internal DB — there is no need to hit the public internet
+// at all in the common case.
 //
-// Strategy: try the underlying mmbiz URL directly first (HTTPS + correct
-// Referer). If that fails, fall back to the relay. Each attempt has a
-// short timeout so a single dead host can't tie up a Node worker. Failure
-// responses are cached briefly on the browser so a broken cover image
-// does not retry on every navigation.
+// Strategy:
+//   1. Look the requested URL up in `wechat_articles.images` (exact + a few
+//      well-known variants — the cover_url stored on `articles` is sometimes
+//      wrapped in the jintiankansha relay form while the matching row in
+//      `images` carries the bare mmbiz URL, or vice versa).
+//   2. If we have the bytes, stream them straight from the DB.
+//   3. Only fall back to fetching from outside if no row matches (e.g. an
+//      image that hasn't been ingested yet). External fetches use a short
+//      timeout and a hardened multi-strategy chain so a single dead host
+//      can't tie up Node workers.
 
 const PER_ATTEMPT_TIMEOUT_MS = 5_000;
 const FAILURE_CACHE = "public, max-age=300, stale-while-revalidate=600";
@@ -24,10 +30,6 @@ interface FetchAttempt {
   referer?: string;
 }
 
-// Pull the inner mmbiz URL out of the jintiankansha relay form. We use raw
-// string slicing rather than `URL.searchParams.get('src')` because the inner
-// URL itself contains `?` and `&` (e.g. `?wx_fmt=jpeg&...`), which standard
-// URL parsing would chop off.
 function extractRelayInner(rawUrl: string): string | null {
   const marker = "?src=";
   const idx = rawUrl.indexOf(marker);
@@ -36,30 +38,63 @@ function extractRelayInner(rawUrl: string): string | null {
   return inner.length > 0 ? inner : null;
 }
 
-function buildAttempts(rawUrl: string): FetchAttempt[] {
+// Build the set of URL forms a single image might be stored under.
+function urlVariants(rawUrl: string): string[] {
+  const set = new Set<string>([rawUrl]);
+
+  if (rawUrl.includes("jintiankansha.me/get?src=")) {
+    const inner = extractRelayInner(rawUrl);
+    if (inner) {
+      set.add(inner);
+      set.add(inner.replace(/^http:\/\//i, "https://"));
+      set.add(inner.replace(/^https:\/\//i, "http://"));
+    }
+  } else if (/^https?:\/\//i.test(rawUrl)) {
+    set.add(rawUrl.replace(/^http:\/\//i, "https://"));
+    set.add(rawUrl.replace(/^https:\/\//i, "http://"));
+  }
+
+  return [...set];
+}
+
+async function findInternalImage(
+  rawUrl: string,
+): Promise<{ data: Buffer; mime_type: string } | null> {
+  if (!wechatPool) return null;
+  try {
+    const result = await wechatPool.query(
+      `SELECT data, mime_type
+         FROM wechat_articles.images
+        WHERE original_url = ANY($1)
+          AND data IS NOT NULL
+        LIMIT 1`,
+      [urlVariants(rawUrl)],
+    );
+    if (result.rows.length === 0 || !result.rows[0].data) return null;
+    return result.rows[0];
+  } catch {
+    return null;
+  }
+}
+
+function buildFetchAttempts(rawUrl: string): FetchAttempt[] {
   const attempts: FetchAttempt[] = [];
 
-  // 1. If the URL is the jintiankansha relay, prefer the underlying mmbiz
-  //    source (upgraded to HTTPS) with a wechat Referer.
   if (rawUrl.includes("jintiankansha.me/get?src=")) {
     const inner = extractRelayInner(rawUrl);
     if (inner) {
       const httpsInner = inner.replace(/^http:\/\//i, "https://");
       attempts.push({ url: httpsInner, referer: "https://mp.weixin.qq.com/" });
-      // Some mmbiz hosts only accept HTTP; try that variant too.
       if (httpsInner !== inner) {
         attempts.push({ url: inner, referer: "https://mp.weixin.qq.com/" });
       }
     }
   } else if (/^https?:\/\/mmbiz\.qpic\.cn\//i.test(rawUrl)) {
-    // Direct mmbiz URL — same Referer trick.
     const httpsUrl = rawUrl.replace(/^http:\/\//i, "https://");
     attempts.push({ url: httpsUrl, referer: "https://mp.weixin.qq.com/" });
   }
 
-  // 2. As a final fallback, try whatever the caller actually asked for.
   attempts.push({ url: rawUrl });
-
   return attempts;
 }
 
@@ -72,7 +107,6 @@ async function fetchWithTimeout(attempt: FetchAttempt): Promise<Response | null>
       Accept: "image/webp,image/*,*/*;q=0.8",
     };
     if (attempt.referer) headers.Referer = attempt.referer;
-
     const res = await fetch(attempt.url, { signal: controller.signal, headers });
     if (!res.ok || !res.body) return null;
     return res;
@@ -89,7 +123,19 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Missing url parameter" }, { status: 400 });
   }
 
-  for (const attempt of buildAttempts(url)) {
+  // 1. Internal DB — the happy path for any ingested image.
+  const internal = await findInternalImage(url);
+  if (internal) {
+    return new NextResponse(new Uint8Array(internal.data), {
+      headers: {
+        "Content-Type": internal.mime_type || "image/jpeg",
+        "Cache-Control": SUCCESS_CACHE,
+      },
+    });
+  }
+
+  // 2. External fallback for images we never mirrored.
+  for (const attempt of buildFetchAttempts(url)) {
     const upstream = await fetchWithTimeout(attempt);
     if (upstream) {
       return new NextResponse(upstream.body, {


### PR DESCRIPTION
Article images are mirrored into wechat_articles.images.data on ingest, but the proxy-image route was always reaching out to the public internet (img2.jintiankansha.me / mmbiz.qpic.cn) — slow at best and 502 on the corp network when those hosts are unreachable.

The route now resolves the request URL against images.original_url (trying a few well-known variants since the cover_url on `articles` is sometimes stored as the jintiankansha relay form while the matching images row carries the bare mmbiz URL, or vice versa) and streams the bytes straight from the DB. External fetch is reserved for the rare images that were never mirrored, with a hard timeout per attempt and a short negative-cache window on failure.