### PR TITLE
fix(semops): route custom OAI-compat providers through litellm openai/

### DIFF
--- a/apps/semops/services/_lotus_worker.py
+++ b/apps/semops/services/_lotus_worker.py
@@ -118,13 +118,28 @@ def run_rank(
         SemopsRateLimitError,
     )
 
+    # Every BYOK provider we ship (openai, gemini, deepseek, glm, minimax,
+    # kimi, custom-*) is reached through an OpenAI-compatible endpoint —
+    # the user's stored `api_base` (or PROVIDER_MAP default) points at one.
+    # litellm's native provider prefixes (`gemini/`, `deepseek/`, ...) bypass
+    # `api_base` and dispatch through provider-specific SDK paths, and any
+    # non-litellm id (`glm`, `minimax`, `kimi`, `custom-*`, user-typed ids
+    # like `cari-ai4news`) raises "LLM Provider NOT provided".
+    #
+    # Whenever an `api_base` is supplied, pin litellm to its OpenAI client
+    # by prefixing the model with `openai/`. That keeps every BYOK provider
+    # on a single, well-tested path. Without `api_base` (legacy tests only)
+    # fall back to the historical `provider/model` form.
+    provider = lm_config["provider"]
+    model = lm_config["model"]
+    api_base = lm_config.get("api_base")
+
     lm_kwargs: dict[str, Any] = {
-        "model": f"{lm_config['provider']}/{lm_config['model']}",
+        "model": f"openai/{model}" if api_base else f"{provider}/{model}",
         "api_key": lm_config["api_key"],
         "max_batch_size": 5,
         "max_tokens": 4096,
     }
-    api_base = lm_config.get("api_base")
     if api_base:
         lm_kwargs["api_base"] = api_base
 

--- a/apps/semops/tests/test_semantic_operators.py
+++ b/apps/semops/tests/test_semantic_operators.py
@@ -143,6 +143,47 @@ def test_run_rank_configures_lotus_and_resets(monkeypatch):
     assert result == [{"id": "x", "recommendation_reason": "ok"}]
 
 
+def test_run_rank_routes_custom_provider_through_openai_with_api_base(monkeypatch):
+    """Custom / non-litellm providers (e.g. ``cari-ai4news``, ``minimax``,
+    ``custom-…``) must be pinned to litellm's ``openai/`` prefix when an
+    ``api_base`` is supplied — otherwise litellm raises
+    ``BadRequestError: LLM Provider NOT provided``.
+    """
+    calls: list = []
+    _install_fake_lotus(monkeypatch, calls)
+
+    from services import _lotus_worker
+    from services._lotus_worker import run_rank
+
+    monkeypatch.setattr(
+        _lotus_worker, "_default_pipeline", lambda **_: [{"id": "a"}]
+    )
+
+    run_rank(
+        lm_config={
+            "provider": "cari-ai4news",
+            "model": "MiniMaxAI/MiniMax-M2.5",
+            "api_key": "sk-test",
+            "api_base": "https://ai4news.example.com/v1",
+        },
+        candidates=[{"id": "a", "match_text": "x"}],
+        query_text="q",
+        top_k=5,
+        search_k=20,
+        include_reasons=False,
+    )
+
+    lm_calls = [c for c in calls if c[0] == "LM"]
+    assert len(lm_calls) == 1
+    # The non-litellm provider id is replaced by the ``openai/`` prefix so
+    # litellm dispatches through its OpenAI-compatible client. The original
+    # model path (including any slashes like ``MiniMaxAI/...``) is preserved
+    # verbatim after the prefix.
+    assert lm_calls[0][1]["model"] == "openai/MiniMaxAI/MiniMax-M2.5"
+    assert lm_calls[0][1]["api_base"] == "https://ai4news.example.com/v1"
+    assert lm_calls[0][1]["api_key"] == "sk-test"
+
+
 def test_run_rank_resets_lotus_on_pipeline_exception(monkeypatch):
     """Even when the pipeline raises, the finally block resets lotus.settings.lm=None.
 


### PR DESCRIPTION
## Summary

- Matcher workflow was 502-ing with `litellm.BadRequestError: LLM Provider NOT provided` whenever the user's BYOK SemOps model was a non-native-litellm provider (`glm`, `minimax`, `kimi`, `custom-*`, or user-typed ids like `cari-ai4news`).
- The semops worker built the litellm model id as `f"{provider}/{model}"`, which litellm only understands for its own provider prefixes. The chat path was unaffected because it dispatches through langchain's `ChatOpenAI`, not litellm.
- Fix: when `api_base` is supplied (true for every BYOK call — `resolveApiKey` always returns one), prefix the model with `openai/` so litellm routes the call through its OpenAI-compatible client against the supplied base URL. Falls back to `provider/model` when `api_base` is absent (legacy/test path).

## Test plan

- [x] Added regression test `test_run_rank_routes_custom_provider_through_openai_with_api_base` covering the `cari-ai4news/MiniMaxAI/MiniMax-M2.5` failure mode.
- [x] Existing `test_run_rank_configures_lotus_and_resets` still expects `openai/gpt-4o-mini` for the `api_base=None` path — fallback branch preserves that.
- [ ] Re-run the failing matcher job against the `cari-ai4news` endpoint and confirm `POST /api/operators/rank` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)