### PR TITLE
fix(env): document that corp LLM relays must be added to NO_PROXY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,8 +114,17 @@ LANGSMITH_PROJECT=sparkflow-langgraph
 # NO_PROXY: lists every docker service hostname so library-level proxy
 # code (HTTP_PROXY auto-injected by ~/.docker/config.json) skips
 # inter-container traffic. Append your corporate intranet domains.
-NO_PROXY=localhost,127.0.0.1,postgres,redis,searxng,semops,web,workflows-api,ingest-worker,digest-worker,migrate
-no_proxy=localhost,127.0.0.1,postgres,redis,searxng,semops,web,workflows-api,ingest-worker,digest-worker,migrate
+#
+# WATCH OUT: corp LLM endpoints (e.g. an internal MiniMax / DeepSeek relay
+# at https://*.rnd.huawei.com/...) MUST be listed here too. Otherwise the
+# openai SDK's httpx client routes the call through the public HTTP_PROXY,
+# which refuses CONNECT to intranet hosts and surfaces as
+#   litellm.InternalServerError: OpenAIException - Connection error.
+# after a ~78 s TCP wait. Affects semops (litellm path) but NOT chat
+# (langchain path), so the failure looks selective and isolated.
+# Use a leading dot to cover every subdomain at once (httpx supports it).
+NO_PROXY=localhost,127.0.0.1,postgres,redis,searxng,semops,web,workflows-api,ingest-worker,digest-worker,migrate,.huawei.com
+no_proxy=localhost,127.0.0.1,postgres,redis,searxng,semops,web,workflows-api,ingest-worker,digest-worker,migrate,.huawei.com
 
 # Corporate CA bundle — paired with the bind-mount of ./ca-certificates.crt
 # onto /etc/ssl/certs/ca-certificates.crt in docker-compose.server.yml.


### PR DESCRIPTION
Internal LLM endpoints (e.g. https://*.rnd.huawei.com/model/v1) routed through Docker's auto-injected HTTP_PROXY get refused by the corp proxy and surface — only on the litellm/openai-SDK path used by semops — as

  litellm.InternalServerError: OpenAIException - Connection error.

after a ~78s TCP wait. Chat (langchain ChatOpenAI / init_chat_model) hits a different failure mode first, so the same misconfig looks like a semops-only bug. Add a comment so the next person stops looking inside litellm and adds the intranet host to NO_PROXY in their .env. Include .huawei.com as the default sample.