### PR TITLE
fix(semops): disable TLS verify for cari-ai4news to match chat path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,14 @@ no_proxy=localhost,127.0.0.1,postgres,redis,searxng,semops,web,workflows-api,ing
 #   REQUESTS_CA_BUNDLE  — `requests` and `httpx`
 #   CURL_CA_BUNDLE      — libcurl
 # Safe to leave as-is on non-MITM hosts (it's the standard system path).
+#
+# Corp BYOK providers (e.g. AI4News at ai4news.rnd.huawei.com) are signed by
+# private roots that NO public bundle ships. Run this once after `cp .env.example
+# .env` on a corp host, before `docker compose up`:
+#   ./scripts/setup-corp-ca.sh
+# It fetches each corp host's chain, appends the intermediate + root to
+# ./ca-certificates.crt, and dedupes. Idempotent. See the script header for
+# how to add a new host.
 SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/apps/semops/services/_lotus_worker.py
+++ b/apps/semops/services/_lotus_worker.py
@@ -17,6 +17,13 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Providers whose gateways are signed by a private corp CA the public bundle
+# doesn't carry. Mirrors `_build_http_clients` in apps/langgraph/chat_model.py
+# (the chat path uses verify=False for these); semops goes through litellm and
+# lotus.LM doesn't expose a custom httpx client knob, so we flip litellm's
+# module-level ssl_verify flag per-request instead.
+_TLS_INSECURE_PROVIDERS = frozenset({"cari-ai4news"})
+
 
 def init_worker() -> None:
     """Warm-up called once per subprocess at pool creation.
@@ -108,6 +115,7 @@ def run_rank(
     Tests that need to exercise the worker without the real LOTUS pipeline
     monkeypatch ``services._lotus_worker._default_pipeline`` directly.
     """
+    import litellm  # type: ignore
     import lotus  # type: ignore
     from lotus.models import LM  # type: ignore
 
@@ -144,15 +152,26 @@ def run_rank(
     if api_base:
         lm_kwargs["api_base"] = api_base
 
+    # Per-request TLS toggle for corp-CA providers. litellm reads
+    # `litellm.ssl_verify` when it constructs its internal httpx clients on
+    # each completion call, so flipping it before LM(...) is built is enough.
+    # Captured + restored in `finally` to keep other providers in the same
+    # subprocess on normal TLS verification.
+    _orig_ssl_verify = getattr(litellm, "ssl_verify", True)
+    tls_insecure = provider in _TLS_INSECURE_PROVIDERS
+    if tls_insecure:
+        litellm.ssl_verify = False
+
     # Visibility: emit the *resolved* model / api_base on every rank
     # request. Without this, custom-endpoint failures look identical to
     # rate limits in the openai SDK retry loop. Caller's api_key is NOT
     # logged.
     logger.info(
-        "lotus rank dispatch (pid=%s, lm_model=%s, api_base=%s)",
+        "lotus rank dispatch (pid=%s, lm_model=%s, api_base=%s, tls_insecure=%s)",
         os.getpid(),
         lm_kwargs["model"],
         api_base or "<none>",
+        tls_insecure,
     )
 
     lotus.settings.configure(lm=LM(**lm_kwargs))
@@ -222,6 +241,9 @@ def run_rank(
                 os.getpid(),
                 reset_exc,
             )
+        # Always restore ssl_verify so the next request on this subprocess
+        # (which may be a different provider) gets normal TLS verification.
+        litellm.ssl_verify = _orig_ssl_verify
 
 
 def _default_pipeline(

--- a/apps/semops/tests/test_semantic_operators.py
+++ b/apps/semops/tests/test_semantic_operators.py
@@ -15,9 +15,23 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 from unittest.mock import MagicMock
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fake_litellm(monkeypatch):
+    """The worker imports ``litellm`` to toggle ``ssl_verify`` per request.
+    Production has litellm as a transitive dep of lotus-ai; the test env
+    keeps lotus stubbed and so doesn't carry litellm either. Inject a
+    minimal stand-in with a real (mutable) ``ssl_verify`` attr so the
+    worker's read-modify-restore is observable.
+    """
+    fake = types.SimpleNamespace(ssl_verify=True)
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+    return fake
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +81,8 @@ def test_rank_rejects_missing_lm_config():
 def _install_fake_lotus(monkeypatch, calls: list | None = None):
     """Install a fake ``lotus`` + ``lotus.models`` into ``sys.modules``.
 
-    Returns nothing; tests inspect ``calls`` (if passed) to verify the
+    The fake ``litellm`` is supplied by the autouse ``_fake_litellm``
+    fixture above. Tests inspect ``calls`` (if passed) to verify the
     ``configure(lm=...)`` ceremony fired in the right order.
     """
     fake_settings = MagicMock()
@@ -182,6 +197,120 @@ def test_run_rank_routes_custom_provider_through_openai_with_api_base(monkeypatc
     assert lm_calls[0][1]["model"] == "openai/MiniMaxAI/MiniMax-M2.5"
     assert lm_calls[0][1]["api_base"] == "https://ai4news.example.com/v1"
     assert lm_calls[0][1]["api_key"] == "sk-test"
+
+
+def test_run_rank_disables_ssl_verify_for_cari_ai4news(monkeypatch, _fake_litellm):
+    """``cari-ai4news`` is signed by Huawei BPIT Root CA which no public bundle
+    ships. The worker flips ``litellm.ssl_verify=False`` for the duration of
+    the request and restores it after, matching the chat path's verify=False.
+    """
+    _install_fake_lotus(monkeypatch)
+
+    from services import _lotus_worker
+    from services._lotus_worker import run_rank
+
+    observed: dict = {}
+
+    def capture_then_succeed(**_):
+        observed["ssl_verify_during_call"] = _fake_litellm.ssl_verify
+        return [{"id": "a"}]
+
+    monkeypatch.setattr(_lotus_worker, "_default_pipeline", capture_then_succeed)
+
+    assert _fake_litellm.ssl_verify is True  # baseline
+    run_rank(
+        lm_config={
+            "provider": "cari-ai4news",
+            "model": "MiniMaxAI/MiniMax-M2.5",
+            "api_key": "sk-test",
+            "api_base": "https://ai4news.example.com/v1",
+        },
+        candidates=[{"id": "a", "match_text": "x"}],
+        query_text="q",
+        top_k=5,
+        search_k=20,
+        include_reasons=False,
+    )
+
+    assert observed["ssl_verify_during_call"] is False
+    # Restored after the call returns so other providers on this subprocess
+    # keep their normal TLS verification.
+    assert _fake_litellm.ssl_verify is True
+
+
+def test_run_rank_leaves_ssl_verify_untouched_for_regular_providers(
+    monkeypatch, _fake_litellm
+):
+    """Public-CA providers like ``openai`` must keep ``ssl_verify`` at its
+    original value through the entire request — toggling it off would silently
+    weaken TLS for every other tenant in the same subprocess.
+    """
+    _install_fake_lotus(monkeypatch)
+
+    from services import _lotus_worker
+    from services._lotus_worker import run_rank
+
+    observed: dict = {}
+
+    def capture_then_succeed(**_):
+        observed["ssl_verify_during_call"] = _fake_litellm.ssl_verify
+        return [{"id": "a"}]
+
+    monkeypatch.setattr(_lotus_worker, "_default_pipeline", capture_then_succeed)
+
+    _fake_litellm.ssl_verify = "sentinel"  # any non-False, non-True value
+    run_rank(
+        lm_config={
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "sk-test",
+            "api_base": None,
+        },
+        candidates=[{"id": "a", "match_text": "x"}],
+        query_text="q",
+        top_k=5,
+        search_k=20,
+        include_reasons=False,
+    )
+
+    assert observed["ssl_verify_during_call"] == "sentinel"
+    assert _fake_litellm.ssl_verify == "sentinel"
+
+
+def test_run_rank_restores_ssl_verify_on_pipeline_exception(monkeypatch, _fake_litellm):
+    """If the rank pipeline raises while ``ssl_verify`` is flipped, the finally
+    block must still restore it — otherwise the next request reusing this
+    subprocess (potentially a different tenant / provider) would inherit
+    weakened TLS verification.
+    """
+    _install_fake_lotus(monkeypatch)
+
+    from services import _lotus_worker
+    from services._lotus_worker import run_rank
+    from services.errors import SemopsProviderError
+
+    def boom(**_):
+        raise RuntimeError("upstream exploded")
+
+    monkeypatch.setattr(_lotus_worker, "_default_pipeline", boom)
+
+    assert _fake_litellm.ssl_verify is True
+    with pytest.raises(SemopsProviderError):
+        run_rank(
+            lm_config={
+                "provider": "cari-ai4news",
+                "model": "m",
+                "api_key": "sk-test",
+                "api_base": "https://ai4news.example.com/v1",
+            },
+            candidates=[{"id": "a", "match_text": "x"}],
+            query_text="q",
+            top_k=5,
+            search_k=20,
+            include_reasons=False,
+        )
+
+    assert _fake_litellm.ssl_verify is True
 
 
 def test_run_rank_resets_lotus_on_pipeline_exception(monkeypatch):

--- a/scripts/setup-corp-ca.sh
+++ b/scripts/setup-corp-ca.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Bootstrap the CA bundle with corporate intermediate + root certs needed to
+# reach internal BYOK provider gateways (e.g. AI4News at ai4news.rnd.huawei.com).
+#
+# Why this script exists
+# ----------------------
+# semops (apps/semops) reaches BYOK gateways through the litellm/openai SDK,
+# which strictly validates TLS against /etc/ssl/certs/ca-certificates.crt.
+# That bundle is bind-mounted from ./ca-certificates.crt in this repo.
+#
+# Public CAs are in the python base image. Corp internal roots are NOT — e.g.
+# AI4News's chain ends at "Huawei BPIT Root CA", which no public bundle ships.
+# Without those roots, TLS handshake fails with
+#   [SSL: CERTIFICATE_VERIFY_FAILED] unable to get issuer certificate
+# which litellm wraps as
+#   litellm.APIConnectionError: OpenAIException - Connection error.
+# after a long timeout, making it look identical to a proxy failure.
+#
+# The chat path (apps/langgraph/chat_model.py) sidesteps this with verify=False;
+# semops can't easily do the same because lotus.LM wraps litellm.completion at
+# a layer that doesn't expose the httpx client. Fix the bundle instead.
+#
+# What it does
+# ------------
+# For each host in HOSTS:
+#   1. Pulls the chain the server sends via `openssl s_client -showcerts`.
+#   2. Drops the leaf cert (the server's own cert, not a CA).
+#   3. Appends each remaining CA cert to ./ca-certificates.crt if not already
+#      present (dedupes by SHA-256 fingerprint).
+#
+# Idempotent — safe to re-run.
+# Tolerant — silently skips a host if unreachable, so public-network deploys
+# where ai4news isn't relevant don't break.
+#
+# Usage
+# -----
+#   ./scripts/setup-corp-ca.sh
+#   docker compose -f docker-compose.server.yml restart semops
+#
+# Source of truth for which providers need corp CAs:
+#   apps/langgraph/chat_model.py::_OPENAI_COMPAT_BASE_URLS
+# Add a HOST below whenever you add a corp BYOK provider there whose chain
+# isn't anchored at a public root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUNDLE="${BUNDLE:-$REPO_ROOT/ca-certificates.crt}"
+TIMEOUT="${TIMEOUT:-10}"
+
+HOSTS=(
+  "ai4news.rnd.huawei.com:443"
+)
+
+log() { printf '[setup-corp-ca] %s\n' "$*" >&2; }
+
+command -v openssl >/dev/null || { log "openssl not found in PATH"; exit 1; }
+
+touch "$BUNDLE"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fp() {
+  openssl x509 -in "$1" -noout -fingerprint -sha256 2>/dev/null | sed 's/.*=//'
+}
+
+is_ca() {
+  openssl x509 -in "$1" -noout -ext basicConstraints 2>/dev/null | grep -q "CA:TRUE"
+}
+
+subj() {
+  openssl x509 -in "$1" -noout -subject 2>/dev/null | sed 's/^subject=//'
+}
+
+# Index existing certs in the bundle by SHA-256 fingerprint.
+mkdir -p "$TMPDIR/existing"
+awk -v d="$TMPDIR/existing" '/-----BEGIN CERTIFICATE-----/{n++} n>0{print > (d"/c"n".pem")}' "$BUNDLE"
+existing_fps=""
+for f in "$TMPDIR"/existing/c*.pem; do
+  [ -s "$f" ] || continue
+  existing_fps+="$(fp "$f")"$'\n'
+done
+
+appended=0
+for hp in "${HOSTS[@]}"; do
+  host="${hp%:*}"
+  log "fetching chain from $hp"
+
+  if ! chain="$(timeout "$TIMEOUT" sh -c "echo | openssl s_client -showcerts -connect '$hp' -servername '$host' 2>/dev/null")"; then
+    log "  skip: unreachable (timeout ${TIMEOUT}s)"
+    continue
+  fi
+  [ -n "$chain" ] || { log "  skip: empty chain"; continue; }
+
+  mkdir -p "$TMPDIR/chain"
+  rm -f "$TMPDIR"/chain/c*.pem 2>/dev/null || true
+  printf '%s\n' "$chain" \
+    | awk -v d="$TMPDIR/chain" '/-----BEGIN CERTIFICATE-----/{n++} n>0{print > (d"/c"n".pem")}'
+
+  for f in "$TMPDIR"/chain/c*.pem; do
+    [ -s "$f" ] || continue
+    if ! is_ca "$f"; then
+      log "  skip leaf: $(subj "$f")"
+      continue
+    fi
+    cert_fp="$(fp "$f")"
+    [ -n "$cert_fp" ] || continue
+    if printf '%s' "$existing_fps" | grep -qF "$cert_fp"; then
+      log "  already trusted: $(subj "$f")"
+    else
+      log "  appending: $(subj "$f")"
+      cat "$f" >> "$BUNDLE"
+      existing_fps+="$cert_fp"$'\n'
+      appended=$((appended + 1))
+    fi
+  done
+done
+
+log "done: appended $appended new cert(s) to $BUNDLE"
+if [ "$appended" -gt 0 ]; then
+  log "restart semops to pick up new bundle:"
+  log "  docker compose -f docker-compose.server.yml restart semops"
+fi


### PR DESCRIPTION
## Summary
- Flip `litellm.ssl_verify` to False for `cari-ai4news` in the semops worker; restore in `finally` so other providers in the same subprocess keep normal TLS verification. Mirrors `apps/langgraph/chat_model.py::_build_http_clients` which the chat path already uses.
- Ship `scripts/setup-corp-ca.sh` to bootstrap `./ca-certificates.crt` with the corp intermediate + root the public bundle doesn't ship. Idempotent, tolerant of unreachable hosts. Pointer added to `.env.example`.
- 3 new tests + autouse `_fake_litellm` fixture; full suite 32/32 passes.

## Why
On a corp host, `semops` raised `litellm.APIConnectionError: Connection error.` for `cari-ai4news` even after `NO_PROXY` was correctly set. Real root cause was TLS: the openai SDK validates against the bind-mounted `/etc/ssl/certs/ca-certificates.crt`, which didn't include `Huawei BPIT Root CA`. Chat sidesteps this with `verify=False`; lotus/litellm has no clean httpx client injection point, hence the per-request global toggle.

## Test plan
- [ ] \`git pull && docker compose -f docker-compose.server.yml up -d --build semops\` on corp host
- [ ] Trigger a real matcher / digest workflow that hits \`cari-ai4news\`
- [ ] Confirm \`docker logs sparkflow-semops --since 2m | grep "lotus rank"\` shows \`dispatch (... tls_insecure=True)\` and zero \`failed\` entries
- [ ] Confirm a non-\`cari-ai4news\` provider (e.g. an \`openai\` BYOK call) in the same run logs \`tls_insecure=False\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)